### PR TITLE
add supportedOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this package will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.1.0] - 2019-07- 09
+
+### Added:
+- The new option `skipDefaultHeaders`, if set to true, makes EventSource _not_ add the `Accept` and `Cache-Control` request headers that it would normally add. This may be necessary to avoid CORS problems in browsers if the stream URL is in another domain, since there are more restrictions on cross-origin requests that contain these headers.
+- There is a new property, `EventSource.supportedOptions`, that indicates which custom options are available. See "Detecting supported features" in [`README.md`](README.md#detecting-supported-features).
+
 ## [1.0.0] - 2019-01-29
 First release from this fork. Changes from the previous release of the upstream code (1.0.7) are as follows:
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,22 @@ You can define a `proxy` option for the HTTP request to be used. This is typical
 var es = new EventSource(url, {proxy: 'http://your.proxy.com'});
 ```
 
+### Detecting supported features
+
+In cases where the EventSource implementation is determined at runtime (for instance, if you are in a browser that may or may not have native support for EventSource, and you are only loading this polyfill if there is no native support), you may want to  know ahead of time whether certain nonstandard features are available or not.
+
+The special property `EventSource.supportedOptions` is an object containing a `true` value for each property name that is allowed in the constructor parameters. If `EventSource.supportedOptions.somePropertyName` is true, then you are using a version of this polyfill that supports the `somePropertyName` option. If `EventSource.supportedOptions.somePropertyName` is false or undefined, or if `EventSource.supportedOptions` does not exist, then you are using either an older version of the polyfill, or some completely different EventSource implementation.
+
+For instance, if you want to use the `POST` method-- which built-in EventSource implementations in browsers cannot do-- but you do not know for sure whether the current EventSource is this polyfill or a built-in browser version, you should check first whether that option is supported; otherwise, if it's the browser version, it will simply ignore the method option and do a `GET` request instead which probably won't work. So your logic might look like this:
+
+```javascript
+if (EventSource.supportedOptions && EventSource.supportedOptions.method) {
+  var es = new EventSource(url, {method: 'POST'})
+} else {
+  // do whatever you want to do if you can't do a POST request
+}
+```
+
 ## License
 
 MIT-licensed. See LICENSE

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -353,10 +353,16 @@ EventSource.prototype.OPEN = 1
 EventSource.prototype.CLOSED = 2
 
 /**
- * Identifies this EventSource polyfill as supporting setting the
- * method used for connecting to the SSE stream.
+ * Adds the EventSource.supportedOptions property that allows application code to know which
+ * custom options are supported by this polyfill.
  */
-Object.defineProperty(EventSource, 'supportsSettingMethod', {enumerable: true, value: true})
+var supportedOptions = [ 'headers', 'https', 'method', 'proxy', 'skipDefaultHeaders', 'withCredentials' ]
+var supportedOptionsObject = {}
+for (var i in supportedOptions) {
+  Object.defineProperty(supportedOptionsObject, supportedOptions[i], {enumerable: true, value: true})
+  // Using custom properties for this allows us to make them read-only.
+}
+Object.defineProperty(EventSource, 'supportedOptions', {enumerable: true, value: supportedOptionsObject})
 
 /**
  * Closes the connection, if one is made, and sets the readyState attribute to 2 (closed)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launchdarkly-eventsource",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Fork of eventsource package - W3C compliant EventSource client for Node.js and browser (polyfill)",
   "keywords": [
     "eventsource",

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -1306,7 +1306,17 @@ describe('Proxying', function () {
 })
 
 describe('EventSource object', function () {
-  it('declares support for setting method', function () {
-    assert.equal(true, EventSource.supportsSettingMethod)
+  it('declares support for custom properties', function () {
+    assert.equal(true, EventSource.supportedOptions.headers)
+    assert.equal(true, EventSource.supportedOptions.https)
+    assert.equal(true, EventSource.supportedOptions.method)
+    assert.equal(true, EventSource.supportedOptions.proxy)
+    assert.equal(true, EventSource.supportedOptions.skipDefaultHeaders)
+    assert.equal(true, EventSource.supportedOptions.withCredentials)
+  })
+
+  it('does not allow supportedOptions to be modified', function () {
+    EventSource.supportedOptions.headers = false
+    assert.equal(true, EventSource.supportedOptions.headers)
   })
 })


### PR DESCRIPTION
This replaces the `EventSource.supportsSettingMethod` custom property with a more general mechanism for detecting feature support. As described in the readme, the only time you would need this is if 1. you are in a browser and 2. you are not sure whether you're currently using the polyfill or a native implementation.