### PR TITLE
add configurable error/retry behavior with backoff & jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,54 +39,20 @@ you can of course build your own. (The `example/eventsource-polyfill.js` is buil
 
 ## Extensions to the W3C API
 
-### Setting HTTP request headers
-
-You can define custom HTTP headers for the initial HTTP request. This can be useful for e.g. sending cookies or to specify an initial `Last-Event-ID` value.
-
-HTTP headers are defined by assigning a `headers` attribute to the optional `eventSourceInitDict` argument:
+All configurable extended behaviors use the optional `eventSourceInitDict` argument to the `EventSource` constructor. For instance:
 
 ```javascript
-var eventSourceInitDict = {headers: {'Cookie': 'test=test'}};
+var eventSourceInitDict = { initialRetryDelayMillis: 1000, maxRetryDelayMillis: 30000 };
 var es = new EventSource(url, eventSourceInitDict);
 ```
 
-Normally, EventSource will always add the headers `Cache-Control: no-cache` (since an SSE stream should always contain live content, not cached content), and `Accept: text/event-stream`. This could cause problems if you are making a cross-origin request, since CORS has restrictions on what headers can be sent. To turn off the default headers, so that it will _only_ send the headers you specify, set the `skipDefaultHeaders` option to `true`:
+In a browser that is using native `EventSource` the extra argument would simply be ignored, so any code that will run in a browser, if it might or might not be using this polyfill, should assume that these options might or might be used.
 
-```javascript
-var eventSourceInitDict = {
-  headers: {'Cookie': 'test=test'},
-  skipDefaultHeaders: true
-};
-var es = new EventSource(url, eventSourceInitDict);
-```
+### Extensions to event behavior
 
-### Setting HTTP request method/body
+Like the standard `EventSource`, this implementation emits the event `open` when a stream has been started and `error` when a stream has failed for any reason. All events have a single parameter which is an instance of the `Event` class.
 
-By default, EventSource makes a `GET` request. You can specify a different HTTP verb and/or a request body:
-
-```javascript
-var eventSourceInitDict = {method: 'POST', body: 'n=100'};
-var es = new EventSource(url, eventSourceInitDict);
-```
-
-### Special HTTPS configuration
-
-In Node.js, you can customize the behavior of HTTPS requests by specifying, for instance, additional trusted CA certificates. You may use any of the special TLS options supported by Node's [`tls.connect()`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) and [`tls.createSecureContext()`](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) (depending on what version of Node you are using) by putting them in an object in the `https` property of your configuration:
-
-```javascript
-var eventSourceInitDict = {
-  https: {
-    rejectUnauthorized: false  // causes requests to succeed even if the certificate cannot be validated
-  }
-}
-var es = new EventSource(url, eventSourceInitDict);
-```
-
-This only works in Node.js, not in a browser.
-
-### HTTP status code on error events
-
-Unauthorized and redirect error status codes (for example 401, 403, 301, 307) are available in the `status` property in the error event.
+The `error` event has the following extended behavior: for an HTTP error response, the event object will have a `status` property (such as `401`) and optionally a `message` property (such as `"Unauthorized"`).
 
 ```javascript
 es.onerror = function (err) {
@@ -98,12 +64,90 @@ es.onerror = function (err) {
 };
 ```
 
+The following additional events may be emitted:
+
+* `closed`: The stream has been permanently closed, either due to a non-retryable error or because `close()` was called.
+* `end`: The server ended the stream. For backward compatibility, this is not reported as an `error`, but it is still treated as one in terms of the retry logic.
+* `retrying`: After an error, this indicates that `EventSource` will try to reconnect after some delay. The event object's `delayMillis` property indicates the delay in milliseconds.
+
+### Configuring backoff and jitter
+
+By default, `EventSource` automatically attempts to reconnect if a connection attempt fails or if an existing connection is broken. To prevent a flood of requests, there is always a delay before retrying the connection; the default value for this is 1000 milliseconds.
+
+For backward compatibility, the default behavior is to use the same delay each time. However, it is highly recommended that you enable both exponential backoff (the delay doubles on each successive retry, up to a configurable maximum) and jitter (a random amount is subtracted from each delay), so that if a server outage causes clients to all lose their connections at the same time they will not all retry at the same time. The backoff can also be configured to reset back to the initial delay if the stream has remained active for some amount of time.
+
+```javascript
+var eventSourceInitDict = {
+  initialRetryDelay: 2000,         // sets initial retry delay to 2 seconds
+  maxBackoffMillis: 30000,         // enables backoff, with a maximum of 30 seconds
+  retryResetIntervalMillis: 60000, // backoff will reset to initialRetryDelay if stream got an event at least 60 seconds before failing
+  jitterRatio: 0.5                 // each delay will be reduced by a randomized jitter of up to 50%
+};
+```
+
+### Configuring error retry behavior
+
+By default, to mimic the behavior of built-in browser `EventSource` implementations, `EventSource` will retry if a connection cannot be made or if the connection is broken (using whatever retry behavior you have configured, as described above)-- but if it connects and receives an HTTP error status, it will only retry for statuses 500, 502, 503, or 504; otherwise it will just raise an `error` event and disconnect, so the application is responsible for starting a new connection.
+
+If you set the option `errorFilter` to a function that receives an `Error` object and returns `true` or `false`, then `EventSource` will call it for any error-- either an HTTP error or an I/O error. If the function returns `true`, it will proceed with retrying the connection; if it returns `false`, it will end the connection and raise an `error` event. In this example, connections will always be retried unless there is a 401 error:
+
+```javascript:
+var eventSourceInitDict = {
+  errorFilter: function(e) {
+    return e.status !== 401;
+  }
+};
+```
+
+HTTP redirect responses (301/307) with a valid `Location` header are not considered errors, and are always immediately retried with the new URL.
+
+### Setting HTTP request headers
+
+You can define custom HTTP headers for the initial HTTP request. This can be useful for e.g. sending cookies or to specify an initial `Last-Event-ID` value.
+
+HTTP headers are defined by assigning a `headers` attribute to the optional `eventSourceInitDict` argument:
+
+```javascript
+var eventSourceInitDict = { headers: { Cookie: 'test=test' } };
+```
+
+Normally, EventSource will always add the headers `Cache-Control: no-cache` (since an SSE stream should always contain live content, not cached content), and `Accept: text/event-stream`. This could cause problems if you are making a cross-origin request, since CORS has restrictions on what headers can be sent. To turn off the default headers, so that it will _only_ send the headers you specify, set the `skipDefaultHeaders` option to `true`:
+
+```javascript
+var eventSourceInitDict = {
+  headers: { Cookie: 'test=test' },
+  skipDefaultHeaders: true
+};
+```
+
+### Setting HTTP request method/body
+
+By default, EventSource makes a `GET` request. You can specify a different HTTP verb and/or a request body:
+
+```javascript
+var eventSourceInitDict = { method: 'POST', body: 'n=100' };
+```
+
+### Special HTTPS configuration
+
+In Node.js, you can customize the behavior of HTTPS requests by specifying, for instance, additional trusted CA certificates. You may use any of the special TLS options supported by Node's [`tls.connect()`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) and [`tls.createSecureContext()`](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) (depending on what version of Node you are using) by putting them in an object in the `https` property of your configuration:
+
+```javascript
+var eventSourceInitDict = {
+  https: {
+    rejectUnauthorized: false  // causes requests to succeed even if the certificate cannot be validated
+  }
+};
+```
+
+This only works in Node.js, not in a browser.
+
 ### HTTP/HTTPS proxy
 
 You can define a `proxy` option for the HTTP request to be used. This is typically useful if you are behind a corporate firewall.
 
 ```javascript
-var es = new EventSource(url, {proxy: 'http://your.proxy.com'});
+var eventSourceInitDict = { proxy: 'http://your.proxy.com' };
 ```
 
 ### Detecting supported features
@@ -116,7 +160,7 @@ For instance, if you want to use the `POST` method-- which built-in EventSource 
 
 ```javascript
 if (EventSource.supportedOptions && EventSource.supportedOptions.method) {
-  var es = new EventSource(url, {method: 'POST'})
+  var es = new EventSource(url, { method: 'POST' });
 } else {
   // do whatever you want to do if you can't do a POST request
 }
@@ -124,4 +168,4 @@ if (EventSource.supportedOptions && EventSource.supportedOptions.method) {
 
 ## License
 
-MIT-licensed. See LICENSE
+MIT-licensed. See LICENSE.

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -1,3 +1,5 @@
+var retryDelay = require('./retry-delay')
+
 var original = require('original')
 var parse = require('url').parse
 var events = require('events')
@@ -31,6 +33,8 @@ function hasBom (buf) {
  **/
 function EventSource (url, eventSourceInitDict) {
   var readyState = EventSource.CONNECTING
+  var config = eventSourceInitDict || {}
+
   Object.defineProperty(this, 'readyState', {
     get: function () {
       return readyState
@@ -46,30 +50,10 @@ function EventSource (url, eventSourceInitDict) {
   var self = this
   self.reconnectInterval = 1000
 
-  function onConnectionClosed (message) {
-    if (readyState === EventSource.CLOSED) return
-    readyState = EventSource.CONNECTING
-    _emit('error', new Event('error', {message: message}))
-
-    // The url may have been changed by a temporary
-    // redirect. If that's the case, revert it now.
-    if (reconnectUrl) {
-      url = reconnectUrl
-      reconnectUrl = null
-    }
-    setTimeout(function () {
-      if (readyState !== EventSource.CONNECTING) {
-        return
-      }
-      connect()
-    }, self.reconnectInterval)
-  }
-
   var req
   var lastEventId = ''
-  if (eventSourceInitDict && eventSourceInitDict.headers && eventSourceInitDict.headers['Last-Event-ID']) {
-    lastEventId = eventSourceInitDict.headers['Last-Event-ID']
-    delete eventSourceInitDict.headers['Last-Event-ID']
+  if (config.headers && config.headers['Last-Event-ID']) {
+    lastEventId = config.headers['Last-Event-ID']
   }
 
   var discardTrailingNewline = false
@@ -77,19 +61,24 @@ function EventSource (url, eventSourceInitDict) {
   var eventName = ''
 
   var reconnectUrl = null
+  var retryDelayStrategy = new retryDelay.RetryDelayStrategy(
+    config.initialRetryDelayMillis !== null && config.initialRetryDelayMillis !== undefined ? config.initialRetryDelayMillis : 1000,
+    config.retryResetIntervalMillis,
+    config.maxBackoffMillis ? retryDelay.defaultBackoff(config.maxBackoffMillis) : null,
+    config.jitterRatio ? retryDelay.defaultJitter(config.jitterRatio) : null
+  )
 
-  function connect () {
+  function makeRequestOptions() {
     var options = parse(url)
-    var isSecure = options.protocol === 'https:'
-    if (eventSourceInitDict && eventSourceInitDict.skipDefaultHeaders) {
+    if (config.skipDefaultHeaders) {
       options.headers = {}
     } else {
       options.headers = { 'Cache-Control': 'no-cache', 'Accept': 'text/event-stream' }
     }
     if (lastEventId) options.headers['Last-Event-ID'] = lastEventId
-    if (eventSourceInitDict && eventSourceInitDict.headers) {
-      for (var i in eventSourceInitDict.headers) {
-        var header = eventSourceInitDict.headers[i]
+    if (config.headers) {
+      for (var i in config.headers) {
+        var header = config.headers[i]
         if (header) {
           options.headers[i] = header
         }
@@ -98,16 +87,14 @@ function EventSource (url, eventSourceInitDict) {
 
     // Legacy: this should be specified as `eventSourceInitDict.https.rejectUnauthorized`,
     // but for now exists as a backwards-compatibility layer
-    options.rejectUnauthorized = !(eventSourceInitDict && !eventSourceInitDict.rejectUnauthorized)
+    options.rejectUnauthorized = !!config.rejectUnauthorized
 
     // If specify http proxy, make the request to sent to the proxy server,
     // and include the original url in path and Host headers
-    var useProxy = eventSourceInitDict && eventSourceInitDict.proxy
+    var useProxy = config.proxy
     if (useProxy) {
-      var proxy = parse(eventSourceInitDict.proxy)
-      isSecure = proxy.protocol === 'https:'
-
-      options.protocol = isSecure ? 'https:' : 'http:'
+      var proxy = parse(config.proxy)
+      options.protocol = proxy.protocol === 'https:' ? 'https:' : 'http:'
       options.path = url
       options.headers.Host = options.host
       options.hostname = proxy.hostname
@@ -116,13 +103,13 @@ function EventSource (url, eventSourceInitDict) {
     }
 
     // If https options are specified, merge them into the request options
-    if (eventSourceInitDict && eventSourceInitDict.https) {
-      for (var optName in eventSourceInitDict.https) {
+    if (config.https) {
+      for (var optName in config.https) {
         if (httpsOptions.indexOf(optName) === -1) {
           continue
         }
 
-        var option = eventSourceInitDict.https[optName]
+        var option = config.https[optName]
         if (option !== undefined) {
           options[optName] = option
         }
@@ -130,53 +117,99 @@ function EventSource (url, eventSourceInitDict) {
     }
 
     // Pass this on to the XHR
-    if (eventSourceInitDict && eventSourceInitDict.withCredentials !== undefined) {
-      options.withCredentials = eventSourceInitDict.withCredentials
+    if (config.withCredentials !== undefined) {
+      options.withCredentials = config.withCredentials
     }
 
-    if (eventSourceInitDict && eventSourceInitDict.method) {
-      options.method = eventSourceInitDict.method
+    if (config.method) {
+      options.method = config.method
     }
+
+    return options
+  }
+
+  function defaultErrorFilter(error) {
+    if (error.status) {
+      var s = error.status;
+      return s === 500 || s === 502 || s === 503 || s === 504;
+    }
+    return true; // always return I/O errors
+  }
+
+  function failed(error) {
+    if (readyState === EventSource.CLOSED) {
+      return
+    }
+    var errorEvent = error ? new Event('error', error) : new Event('end')
+    var shouldRetry = (config.errorFilter || defaultErrorFilter)(errorEvent)
+    if (shouldRetry) {
+      readyState = EventSource.CONNECTING
+      _emit(errorEvent)
+      scheduleReconnect()
+    } else {
+      _emit(errorEvent)
+      readyState = EventSource.CLOSED
+      _emit(new Event('closed'))
+    }
+  }
+
+  function scheduleReconnect() {
+    if (readyState !== EventSource.CONNECTING) return
+    var delay = retryDelayStrategy.nextRetryDelay(new Date().getTime())
+
+    // The url may have been changed by a temporary redirect. If that's the case, revert it now.
+    if (reconnectUrl) {
+      url = reconnectUrl
+      reconnectUrl = null
+    }
+    
+    var event = new Event('retrying')
+    event.delayMillis = delay
+    _emit(event)
+    
+    setTimeout(function() {
+      if (readyState !== EventSource.CONNECTING) return
+      connect()
+    }, delay)
+  }
+
+  function connect() {
+    var options = makeRequestOptions()
+    var isSecure = options.protocol === 'https:'
 
     req = (isSecure ? https : http).request(options, function (res) {
-      // Handle HTTP errors
-      if (res.statusCode === 500 || res.statusCode === 502 || res.statusCode === 503 || res.statusCode === 504) {
-        _emit('error', new Event('error', {status: res.statusCode, message: res.statusMessage}))
-        onConnectionClosed()
-        return
-      }
-
       // Handle HTTP redirects
       if (res.statusCode === 301 || res.statusCode === 307) {
         if (!res.headers.location) {
           // Server sent redirect response without Location header.
-          _emit('error', new Event('error', {status: res.statusCode, message: res.statusMessage}))
+          failed({ status: res.statusCode, message: res.statusMessage })
           return
         }
         if (res.statusCode === 307) reconnectUrl = url
         url = res.headers.location
-        process.nextTick(connect)
+        process.nextTick(connect) // don't go through the scheduleReconnect logic since this isn't an error
         return
       }
 
+      // Handle HTTP errors
       if (res.statusCode !== 200) {
-        _emit('error', new Event('error', {status: res.statusCode, message: res.statusMessage}))
-        return self.close()
+        failed({ status: res.statusCode, message: res.statusMessage })
+        return
       }
 
       readyState = EventSource.OPEN
       res.on('close', function () {
         res.removeAllListeners('close')
         res.removeAllListeners('end')
-        onConnectionClosed()
+        failed()
       })
 
       res.on('end', function () {
         res.removeAllListeners('close')
         res.removeAllListeners('end')
-        onConnectionClosed()
+        failed()
       })
-      _emit('open', new Event('open'))
+      _emit(new Event('open'))
 
       // text/event-stream parser adapted from webkit's
       // Source/WebCore/page/EventSource.cpp
@@ -235,12 +268,12 @@ function EventSource (url, eventSourceInitDict) {
       })
     })
 
-    if (eventSourceInitDict && eventSourceInitDict.body) {
-      req.write(eventSourceInitDict.body)
+    if (config.body) {
+      req.write(config.body)
     }
 
     req.on('error', function (err) {
-      onConnectionClosed(err.message)
+      failed({ message: err.message })
     })
 
     if (req.setNoDelay) req.setNoDelay(true)
@@ -249,9 +282,9 @@ function EventSource (url, eventSourceInitDict) {
 
   connect()
 
-  function _emit () {
-    if (self.listeners(arguments[0]).length > 0) {
-      self.emit.apply(self, arguments)
+  function _emit(event) {
+    if (event) {
+      self.emit(event.type, event)
     }
   }
 
@@ -260,18 +293,25 @@ function EventSource (url, eventSourceInitDict) {
     readyState = EventSource.CLOSED
     if (req.abort) req.abort()
     if (req.xhr && req.xhr.abort) req.xhr.abort()
+    _emit(new Event('closed'))
+  }
+
+  function receivedEvent(event) {
+    retryDelayStrategy.setGoodSince(new Date().getTime())
+    _emit(event)
   }
 
   function parseEventStreamLine (buf, pos, fieldLength, lineLength) {
     if (lineLength === 0) {
       if (data.length > 0) {
         var type = eventName || 'message'
-        _emit(type, new MessageEvent(type, {
+        var event = new MessageEvent(type, {
           data: data.slice(0, -1), // remove trailing newline
           lastEventId: lastEventId,
           origin: original(url)
-        }))
+        })
         data = ''
+        receivedEvent(event)
       }
       eventName = void 0
     } else if (fieldLength > 0) {
@@ -301,6 +341,7 @@ function EventSource (url, eventSourceInitDict) {
         var retry = parseInt(value, 10)
         if (!Number.isNaN(retry)) {
           self.reconnectInterval = retry
+          retryDelayStrategy.setBaseDelay(retry)
         }
       }
     }
@@ -314,7 +355,7 @@ module.exports = {
 util.inherits(EventSource, events.EventEmitter)
 EventSource.prototype.constructor = EventSource; // make stacktraces readable
 
-['open', 'error', 'message'].forEach(function (method) {
+['open', 'error', 'message', 'retrying', 'closed'].forEach(function (method) {
   Object.defineProperty(EventSource.prototype, 'on' + method, {
     /**
      * Returns the current listener
@@ -356,7 +397,19 @@ EventSource.prototype.CLOSED = 2
  * Adds the EventSource.supportedOptions property that allows application code to know which
  * custom options are supported by this polyfill.
  */
-var supportedOptions = [ 'headers', 'https', 'method', 'proxy', 'skipDefaultHeaders', 'withCredentials' ]
+var supportedOptions = [
+  'errorFilter',
+  'headers',
+  'https',
+  'initialRetryDelayMillis',
+  'jitterRatio',
+  'maxBackoffMillis',
+  'method',
+  'proxy',
+  'retryResetIntervalMillis',
+  'skipDefaultHeaders',
+  'withCredentials'
+]
 var supportedOptionsObject = {}
 for (var i in supportedOptions) {
   Object.defineProperty(supportedOptionsObject, supportedOptions[i], {enumerable: true, value: true})

--- a/lib/retry-delay.js
+++ b/lib/retry-delay.js
@@ -1,0 +1,55 @@
+// Encapsulation of configurable backoff/jitter behavior.
+//
+// - The system can either be in a "good" state or a "bad" state. The initial state is "bad"; the
+// caller is responsible for indicating when it transitions to "good". When we ask for a new retry
+// delay, that implies the state is now transitioning to "bad".
+//
+// - There is a configurable base delay, which can be changed at any time (if the SSE server sends
+// us a "retry:" directive).
+//
+// - There are optional strategies for applying backoff and jitter to the delay.
+
+function RetryDelayStrategy(baseDelayMillis, resetIntervalMillis, backoff, jitter) {
+  var currentBaseDelay = baseDelayMillis;
+  var retryCount = 0;
+  var goodSince;
+  return {
+    nextRetryDelay: function(currentTimeMillis) {
+      if (goodSince && resetIntervalMillis && (currentTimeMillis - goodSince >= resetIntervalMillis)) {
+        retryCount = 0;
+      }
+      goodSince = null;
+      var delay = backoff ? backoff(currentBaseDelay, retryCount) : currentBaseDelay;
+      retryCount++;
+      return jitter ? jitter(delay) : delay;
+    },
+
+    setGoodSince: function(goodSinceTimeMillis) {
+      goodSince = goodSinceTimeMillis;
+    },
+
+    setBaseDelay: function(baseDelay) {
+      currentBaseDelay = baseDelay;
+      retryCount = 0;
+    }
+  };
+}
+
+function defaultBackoff(maxDelayMillis) {
+  return function(baseDelayMillis, retryCount) {
+    var d = baseDelayMillis * (2 ** retryCount);
+    return d > maxDelayMillis ? maxDelayMillis : d;
+  };
+}
+
+function defaultJitter(ratio) {
+  return function(computedDelayMillis) {
+    return computedDelayMillis - (Math.random() * ratio * computedDelayMillis);
+  };
+}
+
+module.exports = {
+  RetryDelayStrategy: RetryDelayStrategy,
+  defaultBackoff: defaultBackoff,
+  defaultJitter: defaultJitter
+};

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -126,6 +126,12 @@ function writeEvents (chunks) {
   }
 }
 
+function assertRange(min, max, value) {
+  if (value < min || value > max) {
+    throw new Error('' + value + ' was not in range [' + min + ', ' + max + ']');
+  }
+}
+
 describe('Parser', function () {
   it('parses multibyte characters', function (done) {
     createServer(function (err, server) {
@@ -133,9 +139,11 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['id: 1\ndata: €豆腐\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = function (m) {
         assert.equal('€豆腐', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -147,9 +155,11 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['\n\n\n\nid: 1\ndata: 我現在都看實況不玩遊戲\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = function (m) {
         assert.equal('我現在都看實況不玩遊戲', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -161,8 +171,10 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['data: Hello\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
       es.onmessage = function (m) {
         assert.equal('Hello', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -179,8 +191,10 @@ describe('Parser', function () {
         res.end()
       })
       var es = new EventSource(server.url)
+      es.onerror = function () {}
       es.onmessage = function (m) {
         assert.equal('foo', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -192,8 +206,10 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['data: Hel', 'lo\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
       es.onmessage = function (m) {
         assert.equal('Hello', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -205,6 +221,7 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['data: Hello\n\n', 'data: World\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = first
 
@@ -215,6 +232,7 @@ describe('Parser', function () {
 
       function second (m) {
         assert.equal('World', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -226,9 +244,11 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['data: Hello\ndata:World\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = function (m) {
         assert.equal('Hello\nWorld', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -241,6 +261,7 @@ describe('Parser', function () {
       var chopped = 'data: Aslak\n\ndata: Hellesøy\n\n'.split('')
       server.on('request', writeEvents(chopped))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = first
 
@@ -251,6 +272,7 @@ describe('Parser', function () {
 
       function second (m) {
         assert.equal('Hellesøy', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -272,9 +294,11 @@ describe('Parser', function () {
       })
 
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = function (m) {
         assert.equal('Aslak Hellesøy is the original author', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -287,6 +311,7 @@ describe('Parser', function () {
       var chopped = 'data: Aslak\r\n\r\ndata: Hellesøy\r\n\r\n'.split('')
       server.on('request', writeEvents(chopped))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = first
 
@@ -297,6 +322,7 @@ describe('Parser', function () {
 
       function second (m) {
         assert.equal('Hellesøy', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -309,6 +335,7 @@ describe('Parser', function () {
       var chopped = 'data: Aslak\r\rdata: Hellesøy\r\r'.split('')
       server.on('request', writeEvents(chopped))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = first
 
@@ -319,6 +346,7 @@ describe('Parser', function () {
 
       function second (m) {
         assert.equal('Hellesøy', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -330,9 +358,11 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['event: greeting\ndata: Hello\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.addEventListener('greeting', function (m) {
         assert.equal('Hello', m.data)
+        es.close()
         server.close(done)
       })
     })
@@ -344,6 +374,7 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['event: greeting\ndata: Hello\n\n', 'event: greeting\ndata: World\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
       var numCalled = 0
 
       function onGreeting (m) {
@@ -355,6 +386,7 @@ describe('Parser', function () {
 
       function scheduleDisconnect () {
         assert.equal(1, numCalled)
+        es.close()
         server.close(done)
       }
 
@@ -368,6 +400,7 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['data: Hello\n\n:nothing to see here\n\ndata: World\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = first
 
@@ -378,6 +411,7 @@ describe('Parser', function () {
 
       function second (m) {
         assert.equal('World', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -389,6 +423,7 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['data: Hello\n\n:\n\ndata: World\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = first
 
@@ -399,6 +434,7 @@ describe('Parser', function () {
 
       function second (m) {
         assert.equal('World', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -410,9 +446,11 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['data: line one\ndata:\ndata: line two\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = function (m) {
         assert.equal('line one\n\nline two', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -424,9 +462,11 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['data:\ndata:line one\ndata: line two\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = function (m) {
         assert.equal('\nline one\nline two', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -438,14 +478,16 @@ describe('Parser', function () {
 
       server.on('request', writeEvents(['event:\n\ndata: Hello\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       var originalEmit = es.emit
       es.emit = function (event) {
-        assert.ok(event === 'message' || event === 'newListener')
+        assert.ok(event === 'open' || event === 'message' || event === 'closed')
         return originalEmit.apply(this, arguments)
       }
       es.onmessage = function (m) {
         assert.equal('Hello', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -460,6 +502,7 @@ describe('Parser', function () {
       server.on('request', writeEvents([longMessage]))
 
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = function () {
         server.close(done)
@@ -473,12 +516,16 @@ describe('HTTP Request', function () {
     createServer(function (err, server) {
       if (err) return done(err)
 
+      var es
+
       server.on('request', function (req) {
         assert.equal('no-cache', req.headers['cache-control'])
+        es.close()
         server.close(done)
       })
 
-      new EventSource(server.url)
+      es = new EventSource(server.url);
+      es.onerror = function () {}
     })
   })
 
@@ -493,6 +540,8 @@ describe('HTTP Request', function () {
     createServer(function (err, server) {
       if (err) return done(err)
 
+      var es
+
       server.on('request', function (req) {
         assert.deepStrictEqual(stripIrrelevantHeaders(req.headers), {
           accept: 'text/event-stream',
@@ -501,6 +550,7 @@ describe('HTTP Request', function () {
           cookie: 'test=test',
           'last-event-id': '99'
         })
+        es.close()
         server.close(done)
       })
 
@@ -509,7 +559,8 @@ describe('HTTP Request', function () {
         'Cookie': 'test=test',
         'Last-Event-ID': '99'
       }
-      new EventSource(server.url, {headers: headers})
+      es = new EventSource(server.url, {headers: headers})
+      es.onerror = function () {}
     })
   })
 
@@ -517,12 +568,15 @@ describe('HTTP Request', function () {
     createServer(function (err, server) {
       if (err) return done(err)
 
+      var es
+
       server.on('request', function (req) {
         assert.deepStrictEqual(stripIrrelevantHeaders(req.headers), {
           'user-agent': 'test',
           cookie: 'test=test',
           'last-event-id': '99'
         })
+        es.close()
         server.close(done)
       })
 
@@ -531,10 +585,11 @@ describe('HTTP Request', function () {
         'Cookie': 'test=test',
         'Last-Event-ID': '99'
       }
-      new EventSource(server.url, {
+      es = new EventSource(server.url, {
         headers: headers,
         skipDefaultHeaders: true
       })
+      es.onerror = function () {}
     })
   })
 
@@ -542,7 +597,10 @@ describe('HTTP Request', function () {
     createServer(function (err, server) {
       if (err) return done(err)
 
+      var es
+
       server.on('request', function (req) {
+        es.close()
         assert.equal(req.headers['user-agent'], 'test')
         assert.equal(req.headers['cookie'], 'test=test')
         assert.equal(req.headers['last-event-id'], '99')
@@ -559,7 +617,8 @@ describe('HTTP Request', function () {
 
       assert.doesNotThrow(
         function () {
-          new EventSource(server.url, {headers: headers})
+          es = new EventSource(server.url, {headers: headers})
+          es.onerror = function () {}
         }
       )
     })
@@ -569,12 +628,15 @@ describe('HTTP Request', function () {
     createServer(function (err, server) {
       if (err) return done(err)
 
+      var es
+
       server.on('request', function (req) {
         assert.equal(req.method, 'GET')
         server.close(done)
       })
 
-      new EventSource(server.url)
+      es = new EventSource(server.url)
+      es.onerror = function () {}
     })
   })
 
@@ -584,6 +646,8 @@ describe('HTTP Request', function () {
     createServer(function (err, server) {
       if (err) return done(err)
 
+      var es
+
       server.on('request', function (req) {
         assert.equal(req.method, 'POST')
 
@@ -592,12 +656,14 @@ describe('HTTP Request', function () {
           receivedContent += chunk
         })
         req.on('end', function () {
+          es.close()
           assert.equal(content, receivedContent)
           server.close(done)
         })
       })
 
-      new EventSource(server.url, { method: 'POST', body: content })
+      es = new EventSource(server.url, { method: 'POST', body: content })
+      es.onerror = function () {}
     })
   });
 
@@ -623,7 +689,9 @@ describe('HTTP Request', function () {
         })
 
         var es = new EventSource(server.url)
+        es.onerror = function () {}
         es.onopen = function () {
+          es.close()
           assert.ok(clientRequestedRedirectUrl)
           assert.equal(server.url + redirectSuffix, es.url)
           server.close(done)
@@ -644,6 +712,7 @@ describe('HTTP Request', function () {
 
         var es = new EventSource(server.url)
         es.onerror = function (err) {
+          es.close()
           assert.equal(err.status, status)
           assert.equal(err.message, 'status message')
           server.close(done)
@@ -664,6 +733,7 @@ describe('HTTP Request', function () {
 
         var es = new EventSource(server.url)
         es.onerror = function (err) {
+          es.close()
           assert.equal(err.status, status)
           assert.equal(err.message, 'status message')
           server.close(done)
@@ -680,9 +750,11 @@ describe('HTTPS Support', function () {
 
       server.on('request', writeEvents(['data: hello\n\n']))
       var es = new EventSource(server.url, {rejectUnauthorized: false})
+      es.onerror = function () {}
 
       es.onmessage = function (m) {
         assert.equal('hello', m.data)
+        es.close()
         server.close(done)
       }
     })
@@ -707,7 +779,9 @@ describe('HTTPS Client Certificate Support', function () {
           }
         }
       )
+      es.onerror = function () {}
       es.onmessage = function (m) {
+        es.close()
         assert.equal('hello', m.data)
         server.close(done)
       }
@@ -716,18 +790,19 @@ describe('HTTPS Client Certificate Support', function () {
 })
 
 describe('Reconnection', function () {
-  it('is attempted when server is down', function (done) {
-    var es = new EventSource('http://localhost:' + _port)
-    es.reconnectInterval = 0
+  var briefDelay = 1
 
+  it('is attempted when server is down', function (done) {
+    var es = new EventSource('http://localhost:' + _port, { initialRetryDelayMillis: briefDelay })
     es.onerror = function () {
-      es.onerror = null
+      es.onerror = function () {}
       createServer(function (err, server) {
         if (err) return done(err)
 
         server.on('request', writeEvents(['data: hello\n\n']))
 
         es.onmessage = function (m) {
+          es.close()
           assert.equal('hello', m.data)
           server.close(done)
         }
@@ -740,8 +815,8 @@ describe('Reconnection', function () {
       if (err) return done(err)
 
       server.on('request', writeEvents(['data: hello\n\n']))
-      var es = new EventSource(server.url)
-      es.reconnectInterval = 0
+      var es = new EventSource(server.url, { initialRetryDelayMillis: briefDelay })
+      es.onerror = function (e) {}
 
       es.onmessage = function (m) {
         assert.equal('hello', m.data)
@@ -754,6 +829,7 @@ describe('Reconnection', function () {
 
             server2.on('request', writeEvents(['data: world\n\n']))
             es.onmessage = function (m) {
+              es.close()
               assert.equal('world', m.data)
               server2.close(done)
             }
@@ -772,8 +848,7 @@ describe('Reconnection', function () {
         res.end()
       })
 
-      var es = new EventSource(server.url)
-      es.reconnectInterval = 0
+      var es = new EventSource(server.url, { initialRetryDelayMillis: briefDelay })
 
       var errored = false
 
@@ -789,6 +864,7 @@ describe('Reconnection', function () {
 
             server2.on('request', writeEvents(['data: hello\n\n']))
             es.onmessage = function (m) {
+              es.close()
               assert.equal('hello', m.data)
               server2.close(done)
             }
@@ -803,8 +879,7 @@ describe('Reconnection', function () {
       if (err) return done(err)
 
       server.on('request', writeEvents(['data: hello\n\n']))
-      var es = new EventSource(server.url)
-      es.reconnectInterval = 0
+      var es = new EventSource(server.url, { initialRetryDelayMillis: briefDelay })
 
       es.onmessage = function (m) {
         assert.equal('hello', m.data)
@@ -826,12 +901,14 @@ describe('Reconnection', function () {
           server2.on('request', writeEvents(['data: world\n\n']))
 
           es.onmessage = function (m) {
+            es.close()
             return done(new Error('Unexpected message: ' + m.data))
           }
 
           setTimeout(function () {
             // We have not received any message within 100ms, we can
             // presume this works correctly.
+            es.close()
             server2.close(done)
           }, 100)
         })
@@ -848,8 +925,7 @@ describe('Reconnection', function () {
         res.end()
       })
 
-      var es = new EventSource(server.url)
-      es.reconnectInterval = 0
+      var es = new EventSource(server.url, { initialRetryDelayMillis: briefDelay })
 
       es.onerror = function (e) {
         assert.equal(e.status, 204)
@@ -870,9 +946,50 @@ describe('Reconnection', function () {
             var ival = setInterval(function () {
               if (es.readyState === EventSource.CLOSED) {
                 clearInterval(ival)
+                es.close()
                 server2.close(done)
               }
             }, 5)
+          })
+        })
+      }
+    })
+  })
+
+  it('is attempted for non-200 and non-500 error if errorFilter says so', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      server.on('request', function (req, res) {
+        res.writeHead(204)
+        res.end()
+      })
+
+      var es = new EventSource(server.url, {
+        initialRetryDelayMillis: briefDelay,
+        errorFilter: function(err) {
+          return err.status === 204
+        }
+      })
+
+      var errored = false
+
+      es.onerror = function () {
+        if (errored) return
+        errored = true
+        server.close(function (err) {
+          if (err) return done(err)
+
+          var port = u.parse(es.url).port
+          configureServer(http.createServer(), 'http', port, function (err, server2) {
+            if (err) return done(err)
+
+            server2.on('request', writeEvents(['data: hello\n\n']))
+            es.onmessage = function (m) {
+              assert.equal('hello', m.data)
+              es.close()
+              server2.close(done)
+            }
           })
         })
       }
@@ -885,7 +1002,8 @@ describe('Reconnection', function () {
 
       server.on('request', writeEvents(['id: 10\ndata: Hello\n\n']))
 
-      var es = new EventSource(server.url)
+      var es = new EventSource(server.url, { initialRetryDelayMillis: briefDelay })
+      es.onerror = function () {}
       es.reconnectInterval = 0
 
       es.onmessage = function () {
@@ -897,6 +1015,7 @@ describe('Reconnection', function () {
             if (err) return done(err)
 
             server2.on('request', function (req, res) {
+              es.close()
               assert.equal('10', req.headers['last-event-id'])
               server2.close(done)
             })
@@ -910,12 +1029,16 @@ describe('Reconnection', function () {
     createServer(function (err, server) {
       if (err) return done(err)
 
+      var es
+
       server.on('request', function (req, res) {
+        es.close()
         assert.equal('9', req.headers['last-event-id'])
         server.close(done)
       })
 
-      new EventSource(server.url, {headers: {'Last-Event-ID': '9'}})
+      es = new EventSource(server.url, {headers: {'Last-Event-ID': '9'}})
+      es.onerror = function () {}
     })
   })
 
@@ -925,8 +1048,8 @@ describe('Reconnection', function () {
 
       server.on('request', writeEvents(['data: Hello\n\n']))
 
-      var es = new EventSource(server.url)
-      es.reconnectInterval = 0
+      var es = new EventSource(server.url, { initialRetryDelayMillis: briefDelay })
+      es.onerror = function () {}
 
       es.onmessage = function () {
         server.close(function (err) {
@@ -937,6 +1060,7 @@ describe('Reconnection', function () {
             if (err) return done(err)
 
             server2.on('request', function (req, res) {
+              es.close()
               assert.equal(undefined, req.headers['last-event-id'])
               server2.close(done)
             })
@@ -944,6 +1068,79 @@ describe('Reconnection', function () {
         })
       }
     })
+  })
+})
+
+describe('retry delay', function () {
+  function verifyDelays(options, count, delaysAssertion, done) {
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      server.on('request', function (req, res) {
+        res.writeHead(500)
+        res.end()
+      })
+
+      var counter = 0
+      var delays = []
+      var es = new EventSource(server.url, options)
+      es.onerror = function () {}
+
+      es.onretrying = function (event) {
+        delays.push(event.delayMillis)
+        counter++
+        if (counter >= count) {
+          es.close()
+          try {
+            delaysAssertion(delays)
+            server.close(done)
+          } catch (e) {
+            server.close(function() { done(e) })
+          }
+        }
+      }
+    })
+  }  
+
+  it('uses constant delay by default', function (done) {
+    var delay = 5
+    verifyDelays(
+      { initialRetryDelayMillis: delay },
+      3,
+      function(delays) {
+        assert.deepEqual(delays, [ delay, delay, delay ])
+      },
+      done
+    )
+  })
+  
+  it('can use backoff with maximum', function (done) {
+    var delay = 5
+    var max = 31
+    verifyDelays(
+      { initialRetryDelayMillis: delay, maxBackoffMillis: max },
+      4,
+      function(delays) {
+        assert.deepEqual(delays, [ delay, delay * 2, delay * 4, max ])
+      },
+      done
+    )
+  })
+
+  it('can use backoff with jitter', function (done) {
+    var delay = 5
+    var max = 31
+    verifyDelays(
+      { initialRetryDelayMillis: delay, maxBackoffMillis: max, jitterRatio: 0.5 },
+      3,
+      function(delays) {
+        assert.equal(delays.length, 3)
+        assertRange(delay / 2, delay, delays[0])
+        assertRange(delay, delay * 2, delays[1])
+        assertRange(delay * 2, delay * 4, delays[2])
+      },
+      done
+    )
   })
 })
 
@@ -962,23 +1159,21 @@ describe('readyState', function () {
 
   it('has readystate constants on instances', function (done) {
     var es = new EventSource('http://localhost:' + _port)
+    es.onerror = function () {}
     assert.equal(EventSource.CONNECTING, es.CONNECTING, 'constant CONNECTING missing/invalid')
     assert.equal(EventSource.OPEN, es.OPEN, 'constant OPEN missing/invalid')
     assert.equal(EventSource.CLOSED, es.CLOSED, 'constant CLOSED missing/invalid')
 
-    es.onerror = function () {
-      es.close()
-      done()
-    }
+    es.close()
+    done()
   })
 
   it('is CONNECTING before connection has been established', function (done) {
     var es = new EventSource('http://localhost:' + _port)
+    es.onerror = function () {}
     assert.equal(EventSource.CONNECTING, es.readyState)
-    es.onerror = function () {
-      es.close()
-      done()
-    }
+    es.close()
+    done()
   })
 
   it('is CONNECTING when server has closed the connection', function (done) {
@@ -986,18 +1181,18 @@ describe('readyState', function () {
       if (err) return done(err)
 
       server.on('request', writeEvents([]))
-      var es = new EventSource(server.url)
-      es.reconnectInterval = 0
+      var es = new EventSource(server.url, { initialRetryDelayMillis: 10 })
+
+      es.onerror = function (err) {
+        var state = es.readyState
+        es.close()
+        assert.equal(EventSource.CONNECTING, state)
+        done()
+      }
 
       es.onopen = function (m) {
         server.close(function (err) {
           if (err) return done(err)
-
-          es.onerror = function () {
-            es.onerror = null
-            assert.equal(EventSource.CONNECTING, es.readyState)
-            done()
-          }
         })
       }
     })
@@ -1009,9 +1204,12 @@ describe('readyState', function () {
 
       server.on('request', writeEvents([]))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onopen = function () {
-        assert.equal(EventSource.OPEN, es.readyState)
+        var state = es.readyState
+        es.close()
+        assert.equal(EventSource.OPEN, state)
         server.close(done)
       }
     })
@@ -1023,6 +1221,7 @@ describe('readyState', function () {
 
       server.on('request', writeEvents([]))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onopen = function () {
         es.close()
@@ -1036,9 +1235,10 @@ describe('readyState', function () {
 describe('Methods', function () {
   it('close method exists and can be called to close an eventsource', function (done) {
     createServer(function (err, server) {
+      server.on('request', writeEvents([]))
       if (err) return done(err)
       var es = new EventSource(server.url)
-      server.on('request', writeEvents([]))
+      es.onerror = function () {}
       es.onopen = function () {
         assert.equal(es.close(), undefined)
         server.close(done)
@@ -1055,6 +1255,8 @@ describe('Properties', function () {
   it('url exposes original request url', function () {
     var url = 'http://localhost:' + _port
     var es = new EventSource(url)
+    es.onerror = function () {}
+    es.close()
     assert.equal(url, es.url)
   })
 })
@@ -1066,8 +1268,10 @@ describe('Events', function () {
 
       server.on('request', writeEvents([]))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onopen = function (event) {
+        es.close()
         assert.equal(event.type, 'open')
         server.close(done)
       }
@@ -1080,8 +1284,10 @@ describe('Events', function () {
 
       server.on('request', writeEvents(['data: hello\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = function (event) {
+        es.close()
         assert.equal(event.origin, server.url)
         server.close(done)
       }
@@ -1094,8 +1300,10 @@ describe('Events', function () {
 
       server.on('request', writeEvents([]))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.addEventListener('open', function (event) {
+        es.close()
         assert.equal(event.type, 'open')
         server.close(done)
       })
@@ -1120,9 +1328,11 @@ describe('Events', function () {
         }
       })
       const es = new EventSource(server.url)
+      es.onerror = function () {}
       es.reconnectInterval = 50
 
       setTimeout(function () {
+        es.close()
         server.close(done)
       }, 350)
     })
@@ -1134,6 +1344,7 @@ describe('Events', function () {
 
       server.on('request', writeEvents([]))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.addEventListener('open', function () {
         es.close()
@@ -1153,8 +1364,10 @@ describe('Events', function () {
 
       server.on('request', writeEvents(['id: 123\ndata: hello\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = function (m) {
+        es.close()
         assert.equal(m.lastEventId, '123')
         server.close(done)
       }
@@ -1167,6 +1380,7 @@ describe('Events', function () {
 
       server.on('request', writeEvents(['id: 123\ndata: Hello\n\n', 'data: World\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = first
 
@@ -1175,6 +1389,7 @@ describe('Events', function () {
       }
 
       function second (m) {
+        es.close()
         assert.equal(m.data, 'World')
         assert.equal(m.lastEventId, '123')  // expect to get back the previous event id
         server.close(done)
@@ -1188,8 +1403,10 @@ describe('Events', function () {
 
       server.on('request', writeEvents(['data: World\n\n']))
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.onmessage = function (m) {
+        es.close()
         var enumerableAttributes = Object.keys(m)
         assert.notEqual(enumerableAttributes.indexOf('data'), -1)
         assert.notEqual(enumerableAttributes.indexOf('type'), -1)
@@ -1203,12 +1420,14 @@ describe('Events', function () {
       if (err) return done(err)
 
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       assert.throws(function () { es.dispatchEvent({}) })
       assert.throws(function () { es.dispatchEvent({type: undefined}) })
       assert.throws(function () { es.dispatchEvent({type: ''}) })
       assert.throws(function () { es.dispatchEvent({type: null}) })
 
+      es.close()
       server.close(done)
     })
   })
@@ -1218,8 +1437,10 @@ describe('Events', function () {
       if (err) return done(err)
 
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.addEventListener('greeting', function (m) {
+        es.close()
         server.close(done)
       })
 
@@ -1232,8 +1453,10 @@ describe('Events', function () {
       if (err) return done(err)
 
       var es = new EventSource(server.url)
+      es.onerror = function () {}
 
       es.addEventListener('greeting', function (m) {
+        es.close()
         assert.equal('Hello', m.data)
         server.close(done)
       })

--- a/test/retry-delay_test.js
+++ b/test/retry-delay_test.js
@@ -1,0 +1,112 @@
+var mocha = require('mocha');
+var assert = require('assert');
+var it = mocha.it;
+var describe = mocha.describe;
+
+var retryDelay = require('../lib/retry-delay');
+var RetryDelayStrategy = retryDelay.RetryDelayStrategy;
+
+function assertRange(min, max, value) {
+  if (value < min || value > max) {
+    throw new Error('' + value + ' was not in range [' + min + ', ' + max + ']');
+  }
+}
+  
+describe('retry delay', function() {
+  it('can return fixed delay with no backoff or jitter', function() {
+    var d0 = 1000;
+    var r = new RetryDelayStrategy(d0, 0);
+    var t0 = (new Date()).getTime() - 10000;
+    var d1 = r.nextRetryDelay(t0);
+    var d2 = r.nextRetryDelay(t0 + 1000);
+    var d3 = r.nextRetryDelay(t0 + 2000);
+    assert.equal(d0, d1);
+    assert.equal(d0, d2);
+    assert.equal(d0, d3);
+  });
+
+  it('can use backoff without jitter', function() {
+    var d0 = 10000;
+    var max = 60000;
+    var r = new RetryDelayStrategy(d0, 0, retryDelay.defaultBackoff(max));
+    var t0 = (new Date()).getTime() - 10000;
+    var d1 = r.nextRetryDelay(t0);
+    var d2 = r.nextRetryDelay(t0 + 1000);
+    var d3 = r.nextRetryDelay(t0 + 2000);
+    var d4 = r.nextRetryDelay(t0 + 3000);
+    assert.equal(d0, d1);
+    assert.equal(d0 * 2, d2);
+    assert.equal(d0 * 4, d3);
+    assert.equal(max, d4);
+  });
+
+  it('can use jitter without backoff', function() {
+    var d0 = 1000;
+    var r = new RetryDelayStrategy(d0, 0, null, retryDelay.defaultJitter(0.5));
+    var t0 = (new Date()).getTime() - 10000;
+    var d1 = r.nextRetryDelay(t0);
+    var d2 = r.nextRetryDelay(t0 + 1000);
+    var d3 = r.nextRetryDelay(t0 + 2000);
+    assertRange(d0 / 2, d0, d1);
+    assertRange(d0 / 2, d0, d2);
+    assertRange(d0 / 2, d0, d3);
+  });
+
+  it('can use jitter with backoff', function() {
+    var d0 = 10000;
+    var max = 60000;
+    var r = new RetryDelayStrategy(d0, 0, retryDelay.defaultBackoff(max), retryDelay.defaultJitter(0.5));
+    var t0 = (new Date()).getTime() - 10000;
+    var d1 = r.nextRetryDelay(t0);
+    var d2 = r.nextRetryDelay(t0 + 1000);
+    var d3 = r.nextRetryDelay(t0 + 2000);
+    var d4 = r.nextRetryDelay(t0 + 3000);
+    assertRange(d0 / 2, d0, d1);
+    assertRange(d0, d0 * 2, d2);
+    assertRange(d0 * 2, d0 * 4, d3);
+    assertRange(max / 2, max, d4);
+  });
+
+  it('can reset backoff based on reset interval', function() {
+    var d0 = 10000;
+    var max = 60000;
+    var resetInterval = 45000;
+    var r = new RetryDelayStrategy(d0, resetInterval, retryDelay.defaultBackoff(max));
+    var t0 = (new Date()).getTime() - 10000;
+    r.setGoodSince(t0);
+
+    var t1 = t0 + 1000;
+    var d1 = r.nextRetryDelay(t1);
+    assert.equal(d0, d1);
+
+    var t2 = t1 + d1;
+    r.setGoodSince(t2);
+
+    var t3 = t2 + 10000;
+    d2 = r.nextRetryDelay(t3);
+    assert.equal(d0 * 2, d2);
+
+    var t4 = t3 + d2;
+    r.setGoodSince(t4);
+
+    var t5 = t4 + resetInterval;
+    var d3 = r.nextRetryDelay(t5);
+    assert.equal(d0, d3);
+  });
+
+  it('correctly handles backoff & jitter with high retry count', function() {
+    // This test verifies that we don't get numeric overflow errors due to using a very high exponential
+    // backoff; that should not be a concern in floating point, but this is a sanity check that we're
+    // not doing anything that somehow uses fixed integer precision.
+    var d0 = 1000;
+    var max = 1000 * 60 * 60 * 24 * 365 * 200; // 200 years
+    var retryCount = 35; // 2^35 seconds
+    var r = new RetryDelayStrategy(d0, 0, retryDelay.defaultBackoff(max), retryDelay.defaultJitter(0.5));
+
+    var d1;
+    for (var i = 0; i < retryCount; i++) {
+      d1 = r.nextRetryDelay(new Date().getTime());
+    }
+    assertRange(max / 2, max, d1);
+  });
+});


### PR DESCRIPTION
This adds optional behavior that we will want to use in LaunchDarkly JS-based SDKs for consistency with the stream error/retry behavior in other LaunchDarkly SDKs.

Previously, the behavior of our fork of `js-eventsource` was basically the same as the upstream package. For I/O errors, or HTTP 5xx errors, it would retry with a fixed delay that defaulted to 1000ms (but could be changed via a mutable property of the `EventSource` instance, or by receiving a `retry:` directive from the server); all other errors would be emitted as an `error` event and the stream would close, so the caller was responsible for implementing retries if any for those.

All of the above is still the default for `EventSource`, so these changes should not affect current consumers. New properties related to backoff, jitter, and error retries, are documented in `README.md`. (In the future, we will probably want to provide TypeScript API documentation instead, as we have for our other JS projects.)