### PR TITLE
support passing in an HTTP agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ You can define a `proxy` option for the HTTP request to be used. This is typical
 var eventSourceInitDict = { proxy: 'http://your.proxy.com' };
 ```
 
+In Node.js, you can also set the `agent` option to use a tunneling agent.
+
 ### Detecting supported features
 
 In cases where the EventSource implementation is determined at runtime (for instance, if you are in a browser that may or may not have native support for EventSource, and you are only loading this polyfill if there is no native support), you may want to  know ahead of time whether certain nonstandard features are available or not.

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -182,7 +182,6 @@ function EventSource (url, eventSourceInitDict) {
     var options = makeRequestOptions()
     var isSecure = options.protocol === 'https:'
 
-    if (options.agent) console.log('**** requesting: ' + JSON.stringify(options))
     req = (isSecure ? https : http).request(options, function (res) {
       // Handle HTTP redirects
       if (res.statusCode === 301 || res.statusCode === 307) {
@@ -222,7 +221,6 @@ function EventSource (url, eventSourceInitDict) {
       var isFirst = true
       var buf
       res.on('data', function (chunk) {
-        if (options.agent) console.log('*** data: ' + chunk)
         buf = buf ? Buffer.concat([buf, chunk]) : chunk
         if (isFirst && hasBom(buf)) {
           buf = buf.slice(bom.length)

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -102,6 +102,11 @@ function EventSource (url, eventSourceInitDict) {
       options.port = proxy.port
     }
 
+    // When running in Node, proxies can also be specified as an agent
+    if (config.agent) {
+      options.agent = config.agent
+    }
+
     // If https options are specified, merge them into the request options
     if (config.https) {
       for (var optName in config.https) {
@@ -177,6 +182,7 @@ function EventSource (url, eventSourceInitDict) {
     var options = makeRequestOptions()
     var isSecure = options.protocol === 'https:'
 
+    if (options.agent) console.log('**** requesting: ' + JSON.stringify(options))
     req = (isSecure ? https : http).request(options, function (res) {
       // Handle HTTP redirects
       if (res.statusCode === 301 || res.statusCode === 307) {
@@ -216,6 +222,7 @@ function EventSource (url, eventSourceInitDict) {
       var isFirst = true
       var buf
       res.on('data', function (chunk) {
+        if (options.agent) console.log('*** data: ' + chunk)
         buf = buf ? Buffer.concat([buf, chunk]) : chunk
         if (isFirst && hasBom(buf)) {
           buf = buf.slice(bom.length)

--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
   "devDependencies": {
     "buffer-from": "^1.1.1",
     "express": "^4.15.3",
+    "launchdarkly-js-test-helpers": "1.2.0",
     "mocha": "5.2.0",
     "nyc": "^15.0.0",
     "serve-static": "^1.12.3",
     "ssestream": "^1.0.0",
     "standard": "^10.0.2",
+    "tunnel": "0.0.6",
     "webpack": "^3.5.6"
   },
   "scripts": {


### PR DESCRIPTION
We already added support for a lot of Node HTTP/HTTPS options, but one that we omitted which is needed by the Node SDK is `agent`. The Node SDK uses a tunneling agent to implement HTTP proxies, and all that EventSource needs to do to make this work is to pass the `agent` property along to `http.request()` or `https.request()`... but we had only added the code to do so in the copy of `js-eventsource` that previously existed in the Node SDK, and once we switched over to using this repo, we lost that. As a result, the Node SDK stopped being able to use a proxy for streaming connections.

Note that the test I added for this uses some proxy-related stuff from `launchdarkly-js-test-helpers`, because the proxy helpers that were already in the test code here did not support tunneling. Eventually I'd like to completely rewrite all of this test code and then we can make much better use of all of those helpers, but that's for another day.