### PR TITLE
avoid unnecessary overhead when parsing large messages

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -220,6 +220,8 @@ function EventSource (url, eventSourceInitDict) {
       // Source/WebCore/page/EventSource.cpp
       var isFirst = true
       var buf
+      var startingPos = 0
+      var startingFieldLength = -1
       res.on('data', function (chunk) {
         buf = buf ? Buffer.concat([buf, chunk]) : chunk
         if (isFirst && hasBom(buf)) {
@@ -239,10 +241,10 @@ function EventSource (url, eventSourceInitDict) {
           }
 
           var lineLength = -1
-          var fieldLength = -1
+          var fieldLength = startingFieldLength
           var c
 
-          for (var i = pos; lineLength < 0 && i < length; ++i) {
+          for (var i = startingPos; lineLength < 0 && i < length; ++i) {
             c = buf[i]
             if (c === colon) {
               if (fieldLength < 0) {
@@ -257,7 +259,12 @@ function EventSource (url, eventSourceInitDict) {
           }
 
           if (lineLength < 0) {
+            startingPos = length - pos
+            startingFieldLength = fieldLength
             break
+          } else {
+            startingPos = 0
+            startingFieldLength = -1
           }
 
           parseEventStreamLine(buf, pos, fieldLength, lineLength)

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -515,6 +515,26 @@ describe('Parser', function () {
       }
     })
   })
+  
+  it('parses a relatively huge message across many chunks efficiently', function (done) {
+    this.timeout(1000)
+
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      var longMessageContent = new Array(100000).join('a')
+      var longMessage = 'data: ' + longMessageContent + '\n\n'
+      var longMessageChunks = longMessage.match(/[\s\S]{1,10}/g) // Split the message into chunks of 10 characters
+      server.on('request', writeEvents(longMessageChunks))
+
+      var es = new EventSource(server.url)
+
+      es.onmessage = function (m) {
+        assert.equal(longMessageContent, m.data)
+        server.close(done)
+      }
+    })
+  })
 })
 
 describe('HTTP Request', function () {

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -515,7 +515,7 @@ describe('Parser', function () {
       }
     })
   })
-  
+
   it('parses a relatively huge message across many chunks efficiently', function (done) {
     this.timeout(1000)
 


### PR DESCRIPTION
This is a verbatim borrowing of a PR [from the upstream repo](https://github.com/EventSource/eventsource/pull/130). A customer pointed out the issue and has found that the fix greatly improved performance for them. Basically, the previous logic was re-scanning already-parsed content for no goo reason when a long message arrived in many chunk.

We have diverged enough from upstream at this point that I don't want to try to pull from it right now, although we should still try soon.