### PR TITLE
implement read timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ By default, EventSource makes a `GET` request. You can specify a different HTTP 
 var eventSourceInitDict = { method: 'POST', body: 'n=100' };
 ```
 
+### Read timeout
+
+TCP connections can sometimes fail without the client detecting an I/O error, in which case EventSource could hang forever waiting for events. Setting a `readTimeoutMillis` will cause EventSource to drop and retry the connection if that number of milliseconds ever elapses without receiving any new data from the server. If the server is known to send any "heartbeat" data at regular intervals (such as a `:` comment line, which is ignored in SSE) to indicate that the connection is still alive, set the read timeout to some number longer than that interval.
+
+```javascript
+var eventSourceInitDict = { readTimeoutMillis: 30000 };
+````
+
 ### Special HTTPS configuration
 
 In Node.js, you can customize the behavior of HTTPS requests by specifying, for instance, additional trusted CA certificates. You may use any of the special TLS options supported by Node's [`tls.connect()`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) and [`tls.createSecureContext()`](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) (depending on what version of Node you are using) by putting them in an object in the `https` property of your configuration:

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -222,30 +222,8 @@ function EventSource (url, eventSourceInitDict) {
       var buf
       var startingPos = 0
       var startingFieldLength = -1
-      var readTimeoutTimer = null
-
-      function signalReadTimeout () {
-        if (readyState !== EventSource.OPEN) {
-          return
-        }
-        failed({ message: 'Read timeout, received no data in ' + config.readTimeoutMillis +
-          'ms, assuming connection is dead' })
-      }
-
-      function resetReadTimeout () {
-        if (readTimeoutTimer) {
-          clearTimeout(readTimeoutTimer)
-          readTimeoutTimer = null
-        }
-        if (config.readTimeoutMillis) {
-          readTimeoutTimer = setTimeout(signalReadTimeout, config.readTimeoutMillis)
-        }
-      }
-
-      resetReadTimeout()
 
       res.on('data', function (chunk) {
-        resetReadTimeout()
         buf = buf ? Buffer.concat([buf, chunk]) : chunk
         if (isFirst && hasBom(buf)) {
           buf = buf.slice(bom.length)
@@ -303,12 +281,21 @@ function EventSource (url, eventSourceInitDict) {
       })
     })
 
+    if (config.readTimeoutMillis) {
+      req.setTimeout(config.readTimeoutMillis)
+    }
+
     if (config.body) {
       req.write(config.body)
     }
 
     req.on('error', function (err) {
       failed({ message: err.message })
+    })
+
+    req.on('timeout', function () {
+      failed({ message: 'Read timeout, received no data in ' + config.readTimeoutMillis +
+          'ms, assuming connection is dead' })
     })
 
     if (req.setNoDelay) req.setNoDelay(true)

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -222,7 +222,30 @@ function EventSource (url, eventSourceInitDict) {
       var buf
       var startingPos = 0
       var startingFieldLength = -1
+      var readTimeoutTimer = null
+
+      function signalReadTimeout () {
+        if (readyState !== EventSource.OPEN) {
+          return
+        }
+        failed({ message: 'Read timeout, received no data in ' + config.readTimeoutMillis +
+          'ms, assuming connection is dead' })
+      }
+
+      function resetReadTimeout () {
+        if (readTimeoutTimer) {
+          clearTimeout(readTimeoutTimer)
+          readTimeoutTimer = null
+        }
+        if (config.readTimeoutMillis) {
+          readTimeoutTimer = setTimeout(signalReadTimeout, config.readTimeoutMillis)
+        }
+      }
+
+      resetReadTimeout()
+
       res.on('data', function (chunk) {
+        resetReadTimeout()
         buf = buf ? Buffer.concat([buf, chunk]) : chunk
         if (isFirst && hasBom(buf)) {
           buf = buf.slice(bom.length)

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -1627,7 +1627,8 @@ describe('read timeout', function () {
           assert.equal('request-1-event-1', events[0].data)
           assert.equal('request-2-event-1', events[1].data)
           assert.equal(1, errors.length)
-          assert.match(errors[0].message, /^Read timeout/)
+          assert.ok(/^Read timeout/.test(errors[0].message),
+            'Unexpected error message: ' + errors[0].message)
           server.close(done)
         }
       }

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -1585,6 +1585,89 @@ describe('Proxying', function () {
   })
 })
 
+describe('read timeout', function () {
+  var briefDelay = 1
+
+  function makeStreamHandler (timeBetweenEvents) {
+    var requestCount = 0
+    return function (req, res) {
+      requestCount++
+      res.writeHead(200, {'Content-Type': 'text/event-stream'})
+      var eventPrefix = 'request-' + requestCount
+      res.write('') // turns on chunking
+      res.write('data: ' + eventPrefix + '-event-1\n\n')
+      setTimeout(() => {
+        if (res.writableEnded || res.finished) {
+          // don't try to write any more if the connection's already been closed
+          return
+        }
+        res.write('data: ' + eventPrefix + '-event-2\n\n')
+      }, timeBetweenEvents)
+    }
+  }
+
+  it('drops connection if read timeout elapses', function (done) {
+    var readTimeout = 50
+    var timeBetweenEvents = 100
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      server.on('request', makeStreamHandler(timeBetweenEvents))
+
+      var es = new EventSource(server.url, {
+        initialRetryDelayMillis: briefDelay,
+        readTimeoutMillis: readTimeout
+      })
+      var events = []
+      var errors = []
+      es.onmessage = function (event) {
+        events.push(event)
+        if (events.length === 2) {
+          es.close()
+          assert.equal('request-1-event-1', events[0].data)
+          assert.equal('request-2-event-1', events[1].data)
+          assert.equal(1, errors.length)
+          assert.match(errors[0].message, /^Read timeout/)
+          server.close(done)
+        }
+      }
+      es.onerror = function (err) {
+        errors.push(err)
+      }
+    })
+  })
+
+  it('does not drop connection if read timeout does not elapse', function (done) {
+    var readTimeout = 100
+    var timeBetweenEvents = 50
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      server.on('request', makeStreamHandler(timeBetweenEvents))
+
+      var es = new EventSource(server.url, {
+        initialRetryDelayMillis: briefDelay,
+        readTimeoutMillis: readTimeout
+      })
+      var events = []
+      var errors = []
+      es.onmessage = function (event) {
+        events.push(event)
+        if (events.length === 2) {
+          es.close()
+          assert.equal('request-1-event-1', events[0].data)
+          assert.equal('request-1-event-2', events[1].data)
+          assert.equal(0, errors.length)
+          server.close(done)
+        }
+      }
+      es.onerror = function (err) {
+        errors.push(err)
+      }
+    })
+  })
+})
+
 describe('EventSource object', function () {
   it('declares support for custom properties', function () {
     assert.equal(true, EventSource.supportedOptions.headers)


### PR DESCRIPTION
This adds the ability to automatically drop a stalled connection if we get no data within the specified interval.

That turned out to be pretty simple to do, since it's using the Node HTTP API and all versions of Node that we support have a `setTimeout` method for requests. The wording of the [documentation](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback) isn't crystal clear as to what kind of timeout this is, but since it says it causes `socket.setTimeout()` to be called only after the connection has been made, this can only be a socket/read timeout rather than a connect timeout.

As with previous PRs, you'll see code that's not in our usual style since this forked project has lint rules that aren't what we normally use.

This implementation is meant for Node-based applications. If `js-eventsource` is used as a polyfill in browser code (which it's not well suited to, since it'd be very large due to the use of Node shims) it may or may not be possible to set socket timeouts.