### PR TITLE
PACKAGE: Bump original to remove security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=0.12.0"
   },
   "dependencies": {
-    "original": "^1.0.0"
+    "original": "^1.0.2"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
This is a dependency update PR to fix a security vulnerability relating to `original: 1.0.0` which has a dependency on `url-parse: ^1.4.3` 

From CVE:

url-parse before 1.5.0 mishandles certain uses of backslash such as http:/ and interprets the URI as a relative path.

[CVE Issue Link](https://github.com/advisories/GHSA-9m6j-fcg5-2442)