### PR TITLE
implement contract tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,12 @@ node-template: &node-template
     - store_artifacts:
         path: reports/junit
 
+    - run: make build-contract-tests
+    - run:
+        command: make start-contract-test-service
+        background: true
+    - run: make run-contract-tests
+
 jobs:
   oldest-long-term-support-release:
     <<: *node-template

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/node_modules/
+node_modules
 npm-debug.log
 .DS_Store
 yarn.lock

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+
+TEMP_TEST_OUTPUT=/tmp/sse-contract-test-service.log
+
+build-contract-tests:
+	@cd contract-tests && npm install
+
+start-contract-test-service:
+	@cd contract-tests && node index.js
+
+start-contract-test-service-bg:
+	@echo "Test service output will be captured in $(TEMP_TEST_OUTPUT)"
+	@make start-contract-test-service >$(TEMP_TEST_OUTPUT) 2>&1 &
+
+run-contract-tests:
+	@curl -s https://raw.githubusercontent.com/launchdarkly/sse-contract-tests/v0.0.3/downloader/run.sh \
+      | VERSION=v0 PARAMS="-url http://localhost:8000 -debug -stop-service-at-end" sh
+
+contract-tests: build-contract-tests start-contract-test-service-bg run-contract-tests
+
+.PHONY: build-contract-tests start-contract-test-service run-contract-tests contract-tests

--- a/contract-tests/README.md
+++ b/contract-tests/README.md
@@ -1,5 +1,5 @@
 # SSE client contract test service
 
-This directory contains an implementation of the cross-platform SSE testing protocol defined by https://github.com/launchdarkly/sse-contract-testing. See that project's `README` for details of this protocol, and the kinds of SSE client capabilities that are relevant to the contract tests. This code should not need to be updated unless the SSE client has added or removed such capabilities.
+This directory contains an implementation of the cross-platform SSE testing protocol defined by https://github.com/launchdarkly/sse-contract-tests. See that project's `README` for details of this protocol, and the kinds of SSE client capabilities that are relevant to the contract tests. This code should not need to be updated unless the SSE client has added or removed such capabilities.
 
 To run these tests locally, run `make contract-tests` from the project root directory. This downloads the correct version of the test harness tool automatically.

--- a/contract-tests/README.md
+++ b/contract-tests/README.md
@@ -1,0 +1,5 @@
+# SSE client contract test service
+
+This directory contains an implementation of the cross-platform SSE testing protocol defined by https://github.com/launchdarkly/sse-contract-testing. See that project's `README` for details of this protocol, and the kinds of SSE client capabilities that are relevant to the contract tests. This code should not need to be updated unless the SSE client has added or removed such capabilities.
+
+To run these tests locally, run `make contract-tests` from the project root directory. This downloads the correct version of the test harness tool automatically.

--- a/contract-tests/index.js
+++ b/contract-tests/index.js
@@ -1,0 +1,88 @@
+const http = require('http');
+const url = require('url');
+
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const { StreamEntity } = require('./streamEntity');
+
+const app = express();
+
+const port = 8000;
+
+let streamCounter = 0;
+const streams = {};
+
+app.use(bodyParser.json());
+
+app.get('/', (req, res) => {
+  res.header("Content-Type", "application/json");
+  res.json({
+    'capabilities': [
+      'event-type-listeners',
+      'headers',
+      'post',
+      'read-timeout',
+      'report',
+    ]
+  })
+});
+
+app.delete('/', (req, res) => {
+  console.log('Test service has told us to exit');
+  res.status(204);
+  res.send();
+  process.exit();
+});
+
+app.post('/', (req, res) => {
+  const options = req.body;
+  const tag = options.tag;
+
+  if (!options.streamUrl || !options.callbackUrl) {
+    log(tag, `Received request with incomplete parameters: ${JSON.stringify(options)}`);
+    res.status(400);
+    res.send();
+    return;
+  }
+
+  streamCounter += 1;
+  const streamId = streamCounter.toString()
+  const streamResourceUrl = `/streams/${streamId}`;
+
+  const stream = StreamEntity(options);
+  streams[streamId] = stream;
+
+  res.status(201);
+  res.set('Location', streamResourceUrl);
+  res.send();
+});
+
+app.post('/streams/:id', function(req, res) {
+  const stream = streams[req.params.id];
+  if (!stream) {
+    res.status(404);
+  } else if (!stream.doCommand(req.body)) {
+    res.status(400);
+  } else {
+    res.status(204);
+  }
+  res.send();
+});
+
+app.delete('/streams/:id', function(req, res) {
+  const stream = streams[req.params.id];
+  if (!stream) {
+    res.status(404);
+    res.send();
+    return;
+  }
+  stream.close();
+  delete streams[req.params.id];
+  res.status(204);
+  res.send();
+});
+
+var server = app.listen(port, function () {
+  console.log('Listening on port %d', port);
+});

--- a/contract-tests/package.json
+++ b/contract-tests/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sse-contract-tests",
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "body-parser": "^1.19.0",
+    "express": "^4.17.1",
+    "launchdarkly-eventsource": "file:.."
+  }
+}

--- a/contract-tests/streamEntity.js
+++ b/contract-tests/streamEntity.js
@@ -1,0 +1,132 @@
+const http = require('http');
+const url = require('url');
+
+const { EventSource } = require('launchdarkly-eventsource');
+
+function StreamEntity(options) {
+  const s = {};
+  const listeningForType = {};
+  const messageOutbox = [];
+  const tag = options.tag;
+  let closed = false;
+
+  function log(s) {
+    console.log(`[${tag}] INFO: ${s}`);
+  }
+
+  function logError(tag, s) {
+    console.log(`[${tag}] ERROR: ${s}`);
+  }
+
+  function sendMessage(message) {
+    if (closed) {
+      return;
+    }
+    messageOutbox.push(message);
+    if (messageOutbox.length === 1) {
+      deliverNextMessage();
+    }
+  }
+
+  function deliverNextMessage() {
+    // This logic is necessary to ensure that the callback messages are delivered in
+    // the same order that they were generated in, because events are fired to us in
+    // an asynchronous way that could be interleaved with outgoing HTTP requests.
+    if (messageOutbox.length === 0 || closed) {
+      return;
+    }
+    message = messageOutbox[0];
+    const callbackUrl = url.parse(options.callbackUrl);
+    const reqParams = {
+      ...callbackUrl,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json '}
+    };
+    const req = http.request(reqParams, res => {
+      if (!closed && res.statusCode >= 300) {
+        logError(`Callback request returned HTTP error ${res.statusCode}`);
+      }
+      messageOutbox.shift();
+      deliverNextMessage();
+    });
+    req.on('error', e => {
+      if (!closed) {
+        logError(`Callback request failed: ${e}`);
+      }
+      messageOutbox.shift();
+      deliverNextMessage();
+    });
+    req.write(JSON.stringify(message));
+    req.end();
+  }
+
+  log(`Starting stream from ${options.streamUrl}`);
+
+  const eventSourceParams = {};
+  if (options.headers) {
+    eventSourceParams.headers = options.headers;
+  }
+  if (options.method) {
+    eventSourceParams.method = options.method;
+    eventSourceParams.body = options.body;
+  }
+  if (options.readTimeoutMs) {
+    eventSourceParams.readTimeoutMillis = options.readTimeoutMs;
+  }
+  if (options.initialDelayMs) {
+    eventSourceParams.initialRetryDelayMillis = options.initialDelayMs;
+  }
+
+  s.onMessage = event => {
+    log(`Received message from stream (${event.type})`);
+    sendMessage({
+      kind: 'event',
+      event: {
+        type: event.type,
+        data: event.data,
+        id: event.lastEventId
+      }
+    });
+  };
+
+  s.close = () => {
+    s.closed = true;
+    s.sse.close();
+    log('Test ended');
+  };
+
+  s.doCommand = params => {
+    switch (params.command) {
+      case 'listen':
+        if (!listeningForType[params.type]) {
+          listeningForType[params.type] = true;
+          s.sse.addEventListener(params.type, s.onMessage);
+        }
+        return true;
+
+      default:
+        return false;
+    }
+  }
+
+  s.sse = new EventSource(options.streamUrl, eventSourceParams);
+
+  s.sse.onopen = () => {
+    log('Opened stream');
+  };
+  s.sse.onclosed = () => {
+    log('Closed stream');
+  };
+  s.sse.onmessage = s.onMessage;
+  s.sse.onerror = error => {
+    log(`Received error from stream: ${error}`);
+    sendMessage({
+      kind: 'error',
+      error: error.toString()
+    });
+  };
+
+  return s;
+}
+
+module.exports.StreamEntity = StreamEntity;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "webpack": "^3.5.6"
   },
   "scripts": {
-    "test": "mocha --reporter spec --exit && standard",
+    "test": "mocha --reporter spec --exit && standard 'src/**/*.js' 'test/**/*.js'",
     "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
     "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
   },


### PR DESCRIPTION
See: https://github.com/launchdarkly/sse-contract-tests/pull/1

An example of this running in CI is [here](https://app.circleci.com/pipelines/github/launchdarkly/js-eventsource/64/workflows/21a0a0d9-4389-4e11-bd6d-7b4c2091c50c/jobs/113). All tests are passing, except for ones that are skipped because this implementation lacks some minor features (ability to set Last-Event-Id on first request, ability to detect comments).