### PR TITLE
clean up HTTP request options logic to avoid including extra URL properties (and fix user/password)

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -68,19 +68,19 @@ function EventSource (url, eventSourceInitDict) {
     config.jitterRatio ? retryDelay.defaultJitter(config.jitterRatio) : null
   )
 
-  function makeRequestOptions () {
-    var options = parse(url)
-    if (config.skipDefaultHeaders) {
-      options.headers = {}
-    } else {
-      options.headers = { 'Cache-Control': 'no-cache', 'Accept': 'text/event-stream' }
+  function makeRequestUrlAndOptions () {
+    // Returns { url, options }; url is null/undefined if the URL properties are in options
+    var actualUrl = url
+    var options = { headers: {} }
+    if (!config.skipDefaultHeaders) {
+      options.headers['Cache-Control'] = 'no-cache'
+      options.headers['Accept'] = 'text/event-stream'
     }
     if (lastEventId) options.headers['Last-Event-ID'] = lastEventId
     if (config.headers) {
-      for (var i in config.headers) {
-        var header = config.headers[i]
-        if (header) {
-          options.headers[i] = header
+      for (var key in config.headers) {
+        if (config.headers.hasOwnProperty(key)) {
+          options.headers[key] = config.headers[key]
         }
       }
     }
@@ -91,15 +91,19 @@ function EventSource (url, eventSourceInitDict) {
 
     // If specify http proxy, make the request to sent to the proxy server,
     // and include the original url in path and Host headers
-    var useProxy = config.proxy
-    if (useProxy) {
+    if (config.proxy) {
+      actualUrl = null
+      var parsedUrl = parse(url)
       var proxy = parse(config.proxy)
       options.protocol = proxy.protocol === 'https:' ? 'https:' : 'http:'
       options.path = url
-      options.headers.Host = options.host
+      options.headers.Host = parsedUrl.host
       options.hostname = proxy.hostname
       options.host = proxy.host
       options.port = proxy.port
+      if (proxy.username) {
+        options.auth = proxy.username + ':' + proxy.password
+      }
     }
 
     // When running in Node, proxies can also be specified as an agent
@@ -130,7 +134,7 @@ function EventSource (url, eventSourceInitDict) {
       options.method = config.method
     }
 
-    return options
+    return { url: actualUrl, options: options }
   }
 
   function defaultErrorFilter (error) {
@@ -179,10 +183,11 @@ function EventSource (url, eventSourceInitDict) {
   }
 
   function connect () {
-    var options = makeRequestOptions()
-    var isSecure = options.protocol === 'https:'
+    var urlAndOptions = makeRequestUrlAndOptions()
+    var isSecure = urlAndOptions.options.protocol === 'https:' ||
+      (urlAndOptions.url && urlAndOptions.url.startsWith('https:'))
 
-    req = (isSecure ? https : http).request(options, function (res) {
+    var callback = function (res) {
       // Handle HTTP redirects
       if (res.statusCode === 301 || res.statusCode === 307) {
         if (!res.headers.location) {
@@ -279,7 +284,11 @@ function EventSource (url, eventSourceInitDict) {
           buf = buf.slice(pos)
         }
       })
-    })
+    }
+    var api = isSecure ? https : http
+    req = urlAndOptions.url ?
+      api.request(urlAndOptions.url, urlAndOptions.options, callback) :
+      api.request(urlAndOptions.options, callback)
 
     if (config.readTimeoutMillis) {
       req.setTimeout(config.readTimeoutMillis)


### PR DESCRIPTION
As was pointed out in https://github.com/mswjs/interceptors/issues/188, both this project and the project it was forked from are doing something a bit funny with HTTP request options: we are calling `url.parse` and assuming that every property it returns is also a valid option for `http.request` or `https.request`. That's wrong because:

1. `url.parse` also produces some properties like `hash` that are not valid request properties. Node doesn't care about this, but if there's any other code examining the request properties (as in that GitHub issue) it makes it unnecessarily hard to tell what the object is supposed to be.
2. If the URL has basicauth credentials in it, `url.parse` returns those as two separate properties, whereas `request` expects a single `auth` property in the format `user:password`.

The solution here is, first, under most circumstances we do not need to parse the URL; we can just call `request(url, options, callback)` rather than `request(options, callback)`. So we can build up the options object from an empty `{}` rather than by extending the object returned by `url.parse`. The one case where we do need to parse a URL is if we're using a proxy, because then Node requires you to use a parsed URL for the proxy and set the `path` property to the target URL.

(Note that there are some fairly old-style usages in this code, such as using `hasOwnProperty` when enumerating object keys. This whole project is written in an old style and the linter is set to expect that; we do expect to do a full rewrite at some point.)