### PR TITLE
comply with SSE spec regarding nulls, colons, and partial messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ start-contract-test-service-bg:
 	@make start-contract-test-service >$(TEMP_TEST_OUTPUT) 2>&1 &
 
 run-contract-tests:
-	@curl -s https://raw.githubusercontent.com/launchdarkly/sse-contract-tests/v0.0.3/downloader/run.sh \
-      | VERSION=v0 PARAMS="-url http://localhost:8000 -debug -stop-service-at-end" sh
+	@curl -s https://raw.githubusercontent.com/launchdarkly/sse-contract-tests/v2.0.0/downloader/run.sh \
+      | VERSION=v2 PARAMS="-url http://localhost:8000 -debug -stop-service-at-end" sh
 
 contract-tests: build-contract-tests start-contract-test-service-bg run-contract-tests
 

--- a/contract-tests/streamEntity.js
+++ b/contract-tests/streamEntity.js
@@ -81,9 +81,10 @@ function StreamEntity(options) {
   s.doCommand = params => {
     switch (params.command) {
       case 'listen':
-        if (!listeningForType[params.type]) {
-          listeningForType[params.type] = true;
-          s.sse.addEventListener(params.type, s.onMessage);
+        const eventType = params.listen.type;
+        if (!listeningForType[eventType]) {
+          listeningForType[eventType] = true;
+          s.sse.addEventListener(eventType, s.onMessage);
         }
         return true;
 

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -345,7 +345,7 @@ function EventSource (url, eventSourceInitDict) {
         receivedEvent(event)
       }
       eventName = void 0
-    } else if (fieldLength > 0) {
+    } else {
       var noValue = fieldLength < 0
       var step = 0
       var field = buf.slice(pos, pos + (noValue ? lineLength : fieldLength)).toString()
@@ -367,7 +367,9 @@ function EventSource (url, eventSourceInitDict) {
       } else if (field === 'event') {
         eventName = value
       } else if (field === 'id') {
-        lastEventId = value
+        if (!value.includes("\u0000")) {
+          lastEventId = value
+        }
       } else if (field === 'retry') {
         var retry = parseInt(value, 10)
         if (!Number.isNaN(retry)) {

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -57,8 +57,7 @@ function EventSource (url, eventSourceInitDict) {
   }
 
   var discardTrailingNewline = false
-  var data = ''
-  var eventName = ''
+  var data, eventName, eventId
 
   var reconnectUrl = null
   var retryDelayStrategy = new retryDelay.RetryDelayStrategy(
@@ -207,6 +206,10 @@ function EventSource (url, eventSourceInitDict) {
         return
       }
 
+      data = ''
+      eventName = ''
+      eventId = undefined
+      
       readyState = EventSource.OPEN
       res.on('close', function () {
         res.removeAllListeners('close')
@@ -336,12 +339,16 @@ function EventSource (url, eventSourceInitDict) {
     if (lineLength === 0) {
       if (data.length > 0) {
         var type = eventName || 'message'
+        if (eventId !== undefined) {
+          lastEventId = eventId
+        }
         var event = new MessageEvent(type, {
           data: data.slice(0, -1), // remove trailing newline
           lastEventId: lastEventId,
           origin: original(url)
         })
         data = ''
+        eventId = undefined
         receivedEvent(event)
       }
       eventName = void 0
@@ -368,7 +375,7 @@ function EventSource (url, eventSourceInitDict) {
         eventName = value
       } else if (field === 'id') {
         if (!value.includes("\u0000")) {
-          lastEventId = value
+          eventId = value
         }
       } else if (field === 'retry') {
         var retry = parseInt(value, 10)

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -310,6 +310,19 @@ describe('Parser', () => {
     })
   })
 
+  it('treats field name without colon as a field with an empty value', async () => {
+    await withServer(async server => {
+      server.byDefault(writeEvents(['data\n\ndata\ndata\n\n']))
+
+      await withEventSource(server, async es => {
+        await shouldReceiveMessages(es, [
+          { data: '' },
+          { data: '\n' }
+        ])
+      })
+    })
+  })
+
   it('causes entire event to be ignored for empty event field', async () => {
     await withServer(async server => {
       server.byDefault(writeEvents(['event:\n\ndata: Hello\n\n']))
@@ -950,6 +963,18 @@ describe('Events', function () {
 
         const m2 = await messages.take()
         assert.equal(m2.lastEventId, '123')
+      })
+    })
+  })
+
+  it('ignores event ID that contains a null', async () => {
+    await withServer(async server => {
+      server.byDefault(writeEvents(['id: 12\u00003\ndata: hello\n\n']))
+
+      await withEventSource(server, async es => {
+        const messages = startMessageQueue(es)
+        const m = await messages.take()
+        assert.equal(m.lastEventId, '')
       })
     })
   })


### PR DESCRIPTION
None of these would affect usage in LaunchDarkly based on our services' current behavior, but they are incorrect:

* We're not ignoring `id:` fields that contain a null character.
* We're not treating a line with no colon as equivalent to a field with an empty value; instead we're ignoring it.
* We're not clearing all event state at the start of each connection, so a field from a message that was only partly parsed before the previous connection dropped could be retained.

These were detected with newer contract tests.