### PR TITLE
drop dependency on "original" package

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -1,7 +1,7 @@
 var retryDelay = require('./retry-delay')
 
-var original = require('original')
 var parse = require('url').parse
+var URL = require('url').URL
 var events = require('events')
 var https = require('https')
 var http = require('http')
@@ -66,6 +66,8 @@ function EventSource (url, eventSourceInitDict) {
     config.maxBackoffMillis ? retryDelay.defaultBackoff(config.maxBackoffMillis) : null,
     config.jitterRatio ? retryDelay.defaultJitter(config.jitterRatio) : null
   )
+
+  var streamOriginUrl = new URL(url).origin
 
   function makeRequestUrlAndOptions () {
     // Returns { url, options }; url is null/undefined if the URL properties are in options
@@ -345,7 +347,7 @@ function EventSource (url, eventSourceInitDict) {
         var event = new MessageEvent(type, {
           data: data.slice(0, -1), // remove trailing newline
           lastEventId: lastEventId,
-          origin: original(url)
+          origin: streamOriginUrl
         })
         data = ''
         eventId = undefined

--- a/package.json
+++ b/package.json
@@ -49,9 +49,7 @@
   "engines": {
     "node": ">=0.12.0"
   },
-  "dependencies": {
-    "original": "^1.0.2"
-  },
+  "dependencies": {},
   "standard": {
     "ignore": [
       "example/eventsource-polyfill.js"


### PR DESCRIPTION
The upstream code had already dropped this dependency. Finding the origin of a URL (which we only need to do in order to imitate the EventSource API's behavior of including the stream URL origin in each event— we ourselves don't do anything with it) is easy with the `URL` type; in Node that type is built in, and in browsers we're using a shim for the `url` package that provides it.

Now, like the upstream repo, this package has no dependencies. That means CVE-2022-0686 (on a transitive dependency of `original`) is no longer an issue.