### PR TITLE
bugfix: support IPv6 with zone-index

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -18,8 +18,8 @@ var space = 32
 var lineFeed = 10
 var carriageReturn = 13
 
-function hasBom (buf) {
-  return bom.every(function (charCode, index) {
+function hasBom(buf) {
+  return bom.every(function(charCode, index) {
     return buf[index] === charCode
   })
 }
@@ -31,18 +31,18 @@ function hasBom (buf) {
  * @param {Object} [eventSourceInitDict] extra init params. See README for details.
  * @api public
  **/
-function EventSource (url, eventSourceInitDict) {
+function EventSource(url, eventSourceInitDict) {
   var readyState = EventSource.CONNECTING
   var config = eventSourceInitDict || {}
 
   Object.defineProperty(this, 'readyState', {
-    get: function () {
+    get: function() {
       return readyState
     }
   })
 
   Object.defineProperty(this, 'url', {
-    get: function () {
+    get: function() {
       return url
     }
   })
@@ -69,7 +69,7 @@ function EventSource (url, eventSourceInitDict) {
 
   var streamOriginUrl = new URL(url).origin
 
-  function makeRequestUrlAndOptions () {
+  function makeRequestUrlAndOptions() {
     // Returns { url, options }; url is null/undefined if the URL properties are in options
     var actualUrl = url
     var options = { headers: {} }
@@ -93,6 +93,11 @@ function EventSource (url, eventSourceInitDict) {
     // If hostname is specified, merge them into the request options (to support IpV6 with a zone-index)
     if (config.hostname) {
       options.hostname = config.hostname
+    }
+
+    // If host is specified, merge them into the request options (to support IpV6 with a zone-index)
+    if (config.host) {
+      options.host = config.host
     }
 
     // If specify http proxy, make the request to sent to the proxy server,
@@ -143,7 +148,7 @@ function EventSource (url, eventSourceInitDict) {
     return { url: actualUrl, options: options }
   }
 
-  function defaultErrorFilter (error) {
+  function defaultErrorFilter(error) {
     if (error.status) {
       var s = error.status
       return s === 500 || s === 502 || s === 503 || s === 504
@@ -151,7 +156,7 @@ function EventSource (url, eventSourceInitDict) {
     return true // always return I/O errors
   }
 
-  function failed (error) {
+  function failed(error) {
     if (readyState === EventSource.CLOSED) {
       return
     }
@@ -168,7 +173,7 @@ function EventSource (url, eventSourceInitDict) {
     }
   }
 
-  function scheduleReconnect () {
+  function scheduleReconnect() {
     if (readyState !== EventSource.CONNECTING) return
     var delay = retryDelayStrategy.nextRetryDelay(new Date().getTime())
 
@@ -182,18 +187,18 @@ function EventSource (url, eventSourceInitDict) {
     event.delayMillis = delay
     _emit(event)
 
-    setTimeout(function () {
+    setTimeout(function() {
       if (readyState !== EventSource.CONNECTING) return
       connect()
     }, delay)
   }
 
-  function connect () {
+  function connect() {
     var urlAndOptions = makeRequestUrlAndOptions()
     var isSecure = urlAndOptions.options.protocol === 'https:' ||
       (urlAndOptions.url && urlAndOptions.url.startsWith('https:'))
 
-    var callback = function (res) {
+    var callback = function(res) {
       // Handle HTTP redirects
       if (res.statusCode === 301 || res.statusCode === 307) {
         if (!res.headers.location) {
@@ -218,13 +223,13 @@ function EventSource (url, eventSourceInitDict) {
       eventId = undefined
 
       readyState = EventSource.OPEN
-      res.on('close', function () {
+      res.on('close', function() {
         res.removeAllListeners('close')
         res.removeAllListeners('end')
         failed()
       })
 
-      res.on('end', function () {
+      res.on('end', function() {
         res.removeAllListeners('close')
         res.removeAllListeners('end')
         failed()
@@ -238,7 +243,7 @@ function EventSource (url, eventSourceInitDict) {
       var startingPos = 0
       var startingFieldLength = -1
 
-      res.on('data', function (chunk) {
+      res.on('data', function(chunk) {
         buf = buf ? Buffer.concat([buf, chunk]) : chunk
         if (isFirst && hasBom(buf)) {
           buf = buf.slice(bom.length)
@@ -308,13 +313,15 @@ function EventSource (url, eventSourceInitDict) {
       req.write(config.body)
     }
 
-    req.on('error', function (err) {
+    req.on('error', function(err) {
       failed({ message: err.message })
     })
 
-    req.on('timeout', function () {
-      failed({ message: 'Read timeout, received no data in ' + config.readTimeoutMillis +
-          'ms, assuming connection is dead' })
+    req.on('timeout', function() {
+      failed({
+        message: 'Read timeout, received no data in ' + config.readTimeoutMillis +
+          'ms, assuming connection is dead'
+      })
     })
 
     if (req.setNoDelay) req.setNoDelay(true)
@@ -323,13 +330,13 @@ function EventSource (url, eventSourceInitDict) {
 
   connect()
 
-  function _emit (event) {
+  function _emit(event) {
     if (event) {
       self.emit(event.type, event)
     }
   }
 
-  this._close = function () {
+  this._close = function() {
     if (readyState === EventSource.CLOSED) return
     readyState = EventSource.CLOSED
     if (req.abort) req.abort()
@@ -337,12 +344,12 @@ function EventSource (url, eventSourceInitDict) {
     _emit(new Event('closed'))
   }
 
-  function receivedEvent (event) {
+  function receivedEvent(event) {
     retryDelayStrategy.setGoodSince(new Date().getTime())
     _emit(event)
   }
 
-  function parseEventStreamLine (buf, pos, fieldLength, lineLength) {
+  function parseEventStreamLine(buf, pos, fieldLength, lineLength) {
     if (lineLength === 0) {
       if (data.length > 0) {
         var type = eventName || 'message'
@@ -402,7 +409,7 @@ module.exports = {
 util.inherits(EventSource, events.EventEmitter)
 EventSource.prototype.constructor = EventSource; // make stacktraces readable
 
-['open', 'end', 'error', 'message', 'retrying', 'closed'].forEach(function (method) {
+['open', 'end', 'error', 'message', 'retrying', 'closed'].forEach(function(method) {
   Object.defineProperty(EventSource.prototype, 'on' + method, {
     /**
      * Returns the current listener
@@ -410,7 +417,7 @@ EventSource.prototype.constructor = EventSource; // make stacktraces readable
      * @return {Mixed} the set function or undefined
      * @api private
      */
-    get: function get () {
+    get: function get() {
       var listener = this.listeners(method)[0]
       return listener ? (listener._listener ? listener._listener : listener) : undefined
     },
@@ -422,7 +429,7 @@ EventSource.prototype.constructor = EventSource; // make stacktraces readable
      * @return {Mixed} the set function or undefined
      * @api private
      */
-    set: function set (listener) {
+    set: function set(listener) {
       this.removeAllListeners(method)
       this.addEventListener(method, listener)
     }
@@ -432,9 +439,9 @@ EventSource.prototype.constructor = EventSource; // make stacktraces readable
 /**
  * Ready states
  */
-Object.defineProperty(EventSource, 'CONNECTING', {enumerable: true, value: 0})
-Object.defineProperty(EventSource, 'OPEN', {enumerable: true, value: 1})
-Object.defineProperty(EventSource, 'CLOSED', {enumerable: true, value: 2})
+Object.defineProperty(EventSource, 'CONNECTING', { enumerable: true, value: 0 })
+Object.defineProperty(EventSource, 'OPEN', { enumerable: true, value: 1 })
+Object.defineProperty(EventSource, 'CLOSED', { enumerable: true, value: 2 })
 
 EventSource.prototype.CONNECTING = 0
 EventSource.prototype.OPEN = 1
@@ -459,10 +466,10 @@ var supportedOptions = [
 ]
 var supportedOptionsObject = {}
 for (var i in supportedOptions) {
-  Object.defineProperty(supportedOptionsObject, supportedOptions[i], {enumerable: true, value: true})
+  Object.defineProperty(supportedOptionsObject, supportedOptions[i], { enumerable: true, value: true })
   // Using custom properties for this allows us to make them read-only.
 }
-Object.defineProperty(EventSource, 'supportedOptions', {enumerable: true, value: supportedOptionsObject})
+Object.defineProperty(EventSource, 'supportedOptions', { enumerable: true, value: supportedOptionsObject })
 
 /**
  * Closes the connection, if one is made, and sets the readyState attribute to 2 (closed)
@@ -470,7 +477,7 @@ Object.defineProperty(EventSource, 'supportedOptions', {enumerable: true, value:
  * @see https://developer.mozilla.org/en-US/docs/Web/API/EventSource/close
  * @api public
  */
-EventSource.prototype.close = function () {
+EventSource.prototype.close = function() {
   this._close()
 }
 
@@ -483,7 +490,7 @@ EventSource.prototype.close = function () {
  * @see http://dev.w3.org/html5/websockets/#the-websocket-interface
  * @api public
  */
-EventSource.prototype.addEventListener = function addEventListener (type, listener) {
+EventSource.prototype.addEventListener = function addEventListener(type, listener) {
   if (typeof listener === 'function') {
     // store a reference so we can return the original function again
     listener._listener = listener
@@ -498,7 +505,7 @@ EventSource.prototype.addEventListener = function addEventListener (type, listen
  * @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent
  * @api public
  */
-EventSource.prototype.dispatchEvent = function dispatchEvent (event) {
+EventSource.prototype.dispatchEvent = function dispatchEvent(event) {
   if (!event.type) {
     throw new Error('UNSPECIFIED_EVENT_TYPE_ERR')
   }
@@ -516,7 +523,7 @@ EventSource.prototype.dispatchEvent = function dispatchEvent (event) {
  * @see http://dev.w3.org/html5/websockets/#the-websocket-interface
  * @api public
  */
-EventSource.prototype.removeEventListener = function removeEventListener (type, listener) {
+EventSource.prototype.removeEventListener = function removeEventListener(type, listener) {
   if (typeof listener === 'function') {
     listener._listener = undefined
     this.removeListener(type, listener)
@@ -529,7 +536,7 @@ EventSource.prototype.removeEventListener = function removeEventListener (type, 
  * @see http://www.w3.org/TR/DOM-Level-3-Events/#interface-Event
  * @api private
  */
-function Event (type, optionalProperties) {
+function Event(type, optionalProperties) {
   Object.defineProperty(this, 'type', { writable: false, value: type, enumerable: true })
   if (optionalProperties) {
     for (var f in optionalProperties) {
@@ -546,7 +553,7 @@ function Event (type, optionalProperties) {
  * @see http://www.w3.org/TR/webmessaging/#event-definitions
  * @api private
  */
-function MessageEvent (type, eventInitDict) {
+function MessageEvent(type, eventInitDict) {
   Object.defineProperty(this, 'type', { writable: false, value: type, enumerable: true })
   for (var f in eventInitDict) {
     if (eventInitDict.hasOwnProperty(f)) {

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -90,6 +90,11 @@ function EventSource (url, eventSourceInitDict) {
     // but for now exists as a backwards-compatibility layer
     options.rejectUnauthorized = !!config.rejectUnauthorized
 
+    // If hostname is specified, merge them into the request options (to support IpV6 with a zone-index)
+    if (config.hostname) {
+      options.hostname = config.hostname
+    }
+
     // If specify http proxy, make the request to sent to the proxy server,
     // and include the original url in path and Host headers
     if (config.proxy) {
@@ -211,7 +216,7 @@ function EventSource (url, eventSourceInitDict) {
       data = ''
       eventName = ''
       eventId = undefined
-      
+
       readyState = EventSource.OPEN
       res.on('close', function () {
         res.removeAllListeners('close')


### PR DESCRIPTION
On our linux devices we have to add the zone-index for hostnames based on an IpV6 address e.g.
fe80::240:34ff:fexx:dcxx%eth0.


Because of this the user of the eventsource lib should be able to give the hostname with options (e.g. fe80::260:34ff:fe85:dc61%eth0), otherwise the http(s) request won't be able to resolve the IpV6 address which ends up on an EINVAL error. This may be overridden using the proxy, which is not the case for us. The change should have no side-effects.