### PR TITLE
fix: Ensure that each request can only fail once.

### DIFF
--- a/example/eventsource-polyfill.js
+++ b/example/eventsource-polyfill.js
@@ -7302,7 +7302,6 @@ function EventSource (url, eventSourceInitDict) {
 
   var self = this
   self.reconnectInterval = 1000
-  self.session = 0
 
   var req
   var lastEventId = ''
@@ -7446,8 +7445,6 @@ function EventSource (url, eventSourceInitDict) {
     var urlAndOptions = makeRequestUrlAndOptions()
     var isSecure = urlAndOptions.options.protocol === 'https:' ||
       (urlAndOptions.url && urlAndOptions.url.startsWith('https:'))
-
-    self.session = self.session + 1
 
     // Each request should be able to fail at most once.
     const failOnce = once(failed)

--- a/example/eventsource-polyfill.js
+++ b/example/eventsource-polyfill.js
@@ -7268,13 +7268,13 @@ function hasBom (buf) {
  * Wrap a callback to ensure it can only be called once.
  */
 function once(cb) {
-  let called = false;
+  let called = false
   return (...params) => {
     if(!called) {
-      called = true;
-      cb(...params);
+      called = true
+      cb(...params)
     }
-  };
+  }
 }
 
 /**
@@ -7437,6 +7437,11 @@ function EventSource (url, eventSourceInitDict) {
     }, delay)
   }
 
+  function destroyRequest() {
+    if (req.destroy) req.destroy()
+    if (req.xhr && req.xhr.abort) req.xhr.abort()
+  }
+
   function connect () {
     var urlAndOptions = makeRequestUrlAndOptions()
     var isSecure = urlAndOptions.options.protocol === 'https:' ||
@@ -7445,7 +7450,7 @@ function EventSource (url, eventSourceInitDict) {
     self.session = self.session + 1
 
     // Each request should be able to fail at most once.
-    const failOnce = once(failed);
+    const failOnce = once(failed)
 
     var callback = function (res) {
       // Handle HTTP redirects
@@ -7586,6 +7591,8 @@ function EventSource (url, eventSourceInitDict) {
     req.on('timeout', function () {
       failOnce({ message: 'Read timeout, received no data in ' + config.readTimeoutMillis +
           'ms, assuming connection is dead' })
+      // Timeout doesn't mean that the request is cancelled, just that it has elapsed the timeout.
+      destroyRequest()
     })
 
     if (req.setNoDelay) req.setNoDelay(true)
@@ -7603,8 +7610,9 @@ function EventSource (url, eventSourceInitDict) {
   this._close = function () {
     if (readyState === EventSource.CLOSED) return
     readyState = EventSource.CLOSED
-    if (req.abort) req.abort()
-    if (req.xhr && req.xhr.abort) req.xhr.abort()
+
+    destroyRequest()
+
     _emit(new Event('closed'))
   }
 

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -31,13 +31,13 @@ function hasBom (buf) {
  * Wrap a callback to ensure it can only be called once.
  */
 function once(cb) {
-  let called = false;
+  let called = false
   return (...params) => {
     if(!called) {
-      called = true;
-      cb(...params);
+      called = true
+      cb(...params)
     }
-  };
+  }
 }
 
 /**
@@ -200,6 +200,11 @@ function EventSource (url, eventSourceInitDict) {
     }, delay)
   }
 
+  function destroyRequest() {
+    if (req.destroy) req.destroy()
+    if (req.xhr && req.xhr.abort) req.xhr.abort()
+  }
+
   function connect () {
     var urlAndOptions = makeRequestUrlAndOptions()
     var isSecure = urlAndOptions.options.protocol === 'https:' ||
@@ -208,7 +213,7 @@ function EventSource (url, eventSourceInitDict) {
     self.session = self.session + 1
 
     // Each request should be able to fail at most once.
-    const failOnce = once(failed);
+    const failOnce = once(failed)
 
     var callback = function (res) {
       // Handle HTTP redirects
@@ -349,6 +354,8 @@ function EventSource (url, eventSourceInitDict) {
     req.on('timeout', function () {
       failOnce({ message: 'Read timeout, received no data in ' + config.readTimeoutMillis +
           'ms, assuming connection is dead' })
+      // Timeout doesn't mean that the request is cancelled, just that it has elapsed the timeout.
+      destroyRequest()
     })
 
     if (req.setNoDelay) req.setNoDelay(true)
@@ -366,8 +373,9 @@ function EventSource (url, eventSourceInitDict) {
   this._close = function () {
     if (readyState === EventSource.CLOSED) return
     readyState = EventSource.CLOSED
-    if (req.abort) req.abort()
-    if (req.xhr && req.xhr.abort) req.xhr.abort()
+
+    destroyRequest()
+
     _emit(new Event('closed'))
   }
 

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -65,7 +65,6 @@ function EventSource (url, eventSourceInitDict) {
 
   var self = this
   self.reconnectInterval = 1000
-  self.session = 0
 
   var req
   var lastEventId = ''
@@ -209,8 +208,6 @@ function EventSource (url, eventSourceInitDict) {
     var urlAndOptions = makeRequestUrlAndOptions()
     var isSecure = urlAndOptions.options.protocol === 'https:' ||
       (urlAndOptions.url && urlAndOptions.url.startsWith('https:'))
-
-    self.session = self.session + 1
 
     // Each request should be able to fail at most once.
     const failOnce = once(failed)

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -28,6 +28,19 @@ function hasBom (buf) {
 }
 
 /**
+ * Wrap a callback to ensure it can only be called once.
+ */
+function once(cb) {
+  let called = false;
+  return (...params) => {
+    if(!called) {
+      called = true;
+      cb(...params);
+    }
+  };
+}
+
+/**
  * Creates a new EventSource object
  *
  * @param {String} url the URL to which to connect
@@ -52,6 +65,7 @@ function EventSource (url, eventSourceInitDict) {
 
   var self = this
   self.reconnectInterval = 1000
+  self.session = 0
 
   var req
   var lastEventId = ''
@@ -191,12 +205,17 @@ function EventSource (url, eventSourceInitDict) {
     var isSecure = urlAndOptions.options.protocol === 'https:' ||
       (urlAndOptions.url && urlAndOptions.url.startsWith('https:'))
 
+    self.session = self.session + 1
+
+    // Each request should be able to fail at most once.
+    const failOnce = once(failed);
+
     var callback = function (res) {
       // Handle HTTP redirects
       if (res.statusCode === 301 || res.statusCode === 307) {
         if (!res.headers.location) {
           // Server sent redirect response without Location header.
-          failed({ status: res.statusCode, message: res.statusMessage })
+          failOnce({ status: res.statusCode, message: res.statusMessage })
           return
         }
         if (res.statusCode === 307) reconnectUrl = url
@@ -207,7 +226,7 @@ function EventSource (url, eventSourceInitDict) {
 
       // Handle HTTP errors
       if (res.statusCode !== 200) {
-        failed({ status: res.statusCode, message: res.statusMessage })
+        failOnce({ status: res.statusCode, message: res.statusMessage })
         return
       }
 
@@ -219,13 +238,13 @@ function EventSource (url, eventSourceInitDict) {
       res.on('close', function () {
         res.removeAllListeners('close')
         res.removeAllListeners('end')
-        failed()
+        failOnce()
       })
 
       res.on('end', function () {
         res.removeAllListeners('close')
         res.removeAllListeners('end')
-        failed()
+        failOnce()
       })
       _emit(new Event('open'))
 
@@ -324,11 +343,11 @@ function EventSource (url, eventSourceInitDict) {
     }
 
     req.on('error', function (err) {
-      failed({ message: err.message })
+      failOnce({ message: err.message })
     })
 
     req.on('timeout', function () {
-      failed({ message: 'Read timeout, received no data in ' + config.readTimeoutMillis +
+      failOnce({ message: 'Read timeout, received no data in ' + config.readTimeoutMillis +
           'ms, assuming connection is dead' })
     })
 


### PR DESCRIPTION
On WSL with no network, or running docker without a network, the 'error' and 'timeout' callbacks would both be called. The timeout should only happen after the specified timeout, 5 minutes in the node SDK, but happens immediately under either of those conditions.

This change ensures that each request can only fail one time.